### PR TITLE
feat: disable non-default services by default

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,7 +37,7 @@ RUN cd /etc/yum.repos.d/ \
 RUN sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=60s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=60s/' /etc/systemd/system.conf && \
-    systemctl enable cockpit.service && \
+    systemctl disable docker.socket && \
     systemctl enable ensure-var-log-audit-dir.service && \
     systemctl enable rpm-ostreed-automatic.timer && \
     rm /etc/ssh/sshd_config.d/40-disable-passwords.conf && \

--- a/README.md
+++ b/README.md
@@ -26,13 +26,9 @@ WARNING: This image has **not** been heavily tested, though the underlying compo
 
 One can layer packages directly on a machine running uCore or use this image as a base for further customized OCI builds.
 
-Note: per [cockpit instructions](https://cockpit-project.org/running.html#coreos) the cockpit-ws RPM is **not** installed, rather it is available as a podman container. This image has pre-configured cockpit to run on system boot, but it can be disabled:
-
-```bash
-sudo systemctl disable --now cockpit.service
-```
-
 This image should be suitable for use on bare metal or on virtual machines where you wish to run containerized workloads.
+
+Note: per [cockpit instructions](https://cockpit-project.org/running.html#coreos) the cockpit-ws RPM is **not** installed, rather it is available as a podman container.
 
 ## Tips and Tricks
 
@@ -40,7 +36,15 @@ These images are immutable, you can't, and really shouldn't, install packages li
 
 CoreOS expects the user to run services using [podman](https://podman.io). `moby-engine`, the free Docker implementation, is installed for those who desire docker instead of podman.
 
-NOTE: CoreOS [cautions against](https://docs.fedoraproject.org/en-US/fedora-coreos/faq/#_can_i_run_containers_via_docker_and_podman_at_the_same_time) running podman and docker containers at the same time.
+To maintain this image's suitability as a minimal container host, most add-on services are not auto-enabled.
+
+To activate any of the pre-installed `cockpit`, `docker`, or `tailscale` services:
+
+```bash
+sudo systemctl enable --now SERVICENAME.service
+```
+
+NOTE: CoreOS [cautions against](https://docs.fedoraproject.org/en-US/fedora-coreos/faq/#_can_i_run_containers_via_docker_and_podman_at_the_same_time) running podman and docker containers at the same time.  Thus, `docker.socket` is disabled by default to prevent accidental activate of docker daemon, given podman is the default.
 
 Users may use [distrobox](https://github.com/89luca89/distrobox) to run images of mutable distributions where applications can be installed with traditional package managers. This may be useful for installing interactive utilities such has `htop`, `nmap`, etc. As stated above, however, *services* should run as containers.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ CoreOS expects the user to run services using [podman](https://podman.io). `moby
 
 To maintain this image's suitability as a minimal container host, most add-on services are not auto-enabled.
 
-To activate any of the pre-installed `cockpit`, `docker`, or `tailscale` services:
+To activate any of the pre-installed `cockpit`, `docker`, or `tailscaled` services:
 
 ```bash
 sudo systemctl enable --now SERVICENAME.service


### PR DESCRIPTION
Before usage expands and more services get added, set the baseline of all non-default services being disabled by default.

The significant change is this PR disables `cockpit.service` where we'd previously enabled it. This prevents it from starting by default and downloading the cockpit podman image, where it may not be desired. Users who wish to use it can enable as they would any other service.

Already, `tailscaled.service` and `docker.service` were disabled by default, though `docker.socket` was enabled by default.
`docker.socket` is now specifically disabled with an explanation in README.


