### PR TITLE
feat: provision required directories at boot

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,6 +11,7 @@ ADD post-install.sh /tmp/post-install.sh
 ADD packages.json /tmp/packages.json
 
 COPY etc /etc
+COPY usr /usr
 
 RUN /tmp/build.sh
 RUN /tmp/post-install.sh

--- a/etc/systemd/system/ucore-paths-provision.service
+++ b/etc/systemd/system/ucore-paths-provision.service
@@ -1,13 +1,12 @@
 [Unit]
-Description=Ensure /var/log/audit is present
+Description=Ensure required paths are present on boot
 DefaultDependencies=no
 After=local-fs.target
 Before=auditd.service
 
 [Service]
 Type=oneshot
-ExecStartPre=mkdir -p -m 0700 /var/log/audit
-ExecStart=restorecon -v /var/log/audit
+ExecStart=/usr/sbin/ucore-paths-provision.sh
 RemainAfterExit=yes
 
 [Install]

--- a/etc/systemd/ucore-paths-provision.conf
+++ b/etc/systemd/ucore-paths-provision.conf
@@ -1,0 +1,12 @@
+# some paths are not provisioned properly in CoreOS OCI images
+# at least some due to restrictions on paths in /var
+#
+# ucore-paths-provision.sh will ensure these are created
+# and restore SElinux context where applicable
+#
+# Note: directory paths ONLY
+#DIR_MODE;DIR_PATH
+0700;/var/log/audit
+0755;/var/lib/duperemove
+0755;/var/lib/rpm-state
+0700;/var/lib/setroubleshoot

--- a/post-install.sh
+++ b/post-install.sh
@@ -4,7 +4,7 @@ set -ouex pipefail
 
 systemctl disable docker.socket
 
-systemctl enable ensure-var-log-audit-dir.service
+systemctl enable ucore-paths-provision.service
 systemctl enable rpm-ostreed-automatic.timer
 
 sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf

--- a/usr/sbin/ucore-paths-provision.sh
+++ b/usr/sbin/ucore-paths-provision.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+#
+# some paths are not provisioned properly in CoreOS OCI images
+# at least some due to restrictions on paths in /var
+#
+# ucore-paths-provision.sh will ensure these are created
+# and restore SElinux context where applicable
+#
+CONFIG=/etc/systemd/ucore-paths-provision.conf
+
+for MODE_PATH in $(cat $CONFIG|grep -v ^#); do
+    MP=(${MODE_PATH//;/ })
+    if [ ! -d "${MP[1]}" ]; then
+        mkdir -p -m ${MP[0]} ${MP[1]}
+        restorecon -v ${MP[1]}
+    fi
+done


### PR DESCRIPTION
for directories that are lost due to OCI images not allowing them in /var, etc, this provides a config file which can be used to define the set of dirs (with mode) which should be created, and restorecon on them

only exec mkdir/restorecon if the directory is absent when service runs