### PR TITLE
feat: provide example to autorebase to uCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,30 @@ This image is not currently avaialable for direct install. The user must follow 
 
 All CoreOS installation methods require the user to [produce an Ignition file](https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/). This Ignition file should, at mimimum, set a password and SSH key for the default user (default username is `core`).
 
-### Install and Rebase
+### Install and Manually Rebase
+
+You can rebase any Fedora CoreOS x86_64 installation to uCore.  Installing CoreOS itself can be done through [a number of provisioning methods](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/).
 
 To rebase an Fedora CoreOS machine to the latest uCore (stable):
 
-1. Install CoreOS via [desired installation method](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/)
-1. After you reboot you should [pin the working deployment](https://docs.fedoraproject.org/en-US/fedora-silverblue/faq/#_how_can_i_upgrade_my_system_to_the_next_major_version_for_instance_rawhide_or_an_upcoming_fedora_release_branch_while_keeping_my_current_deployment) which allows you to rollback if required.
-1. SSH to the freshly installed CoreOS system and rebase the OS, then reboot:
+1. Execute the desired `rpm-ostree rebase` command...
+1. Reboot, as instructed.
+1. After rebooting, you should [pin the working deployment](https://docs.fedoraproject.org/en-US/fedora-silverblue/faq/#_how_can_i_upgrade_my_system_to_the_next_major_version_for_instance_rawhide_or_an_upcoming_fedora_release_branch_while_keeping_my_current_deployment) which allows you to rollback if required.
 
 ```bash
+# Fedora CoreOS stable stream
 sudo rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/ucore:stable
+# Fedora CoreOS testing stream, instead use the following
+#sudo rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/ucore:testing
 ```
+
+### Install with Auto-Rebase
+
+Your path to a running uCore can be shortend by using [examples/ucore-autorebase.butane](blob/main/examples/ucore-autorebase.butane) as the starting point for your CoreOS ignition file.
+
+1. As usual, you'll need to [follow the docs to setup a password](https://coreos.github.io/butane/examples/#using-password-authentication). Substitute your password hash for `YOUR_GOOD_PASSWORD_HASH_HERE` in the `ucore-autorebase.butane` file, and add your ssh pub key while you are at it.
+1. Generate an ignition file from your new `ucore-autorebase.butane` [using the butane utility](https://coreos.github.io/butane/getting-started/).
+1. Now install CoreOS for [hypervisor, cloud provider or bare-metal](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/). Your ignition file should work for any platform, auto-rebasing to the `ucore:stable`, rebooting and leaving your install ready to use.
 
 ## Verification
 

--- a/etc/systemd/system/ucore-paths-provision.service
+++ b/etc/systemd/system/ucore-paths-provision.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Ensure required paths are present on boot
+Description=uCore provision required paths on boot
 DefaultDependencies=no
 After=local-fs.target
 Before=auditd.service

--- a/examples/ucore-autorebase.butane
+++ b/examples/ucore-autorebase.butane
@@ -1,0 +1,42 @@
+variant: fcos
+version: 1.4.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - YOUR_SSH_PUB_KEY_HERE
+      password_hash: YOUR_GOOD_PASSWORD_HASH_HERE
+storage:
+  directories:
+    - path: /etc/ucore-autorebase
+      mode: 0754
+  files:
+    - path: /etc/ucore-autorebase/ucore-autorebase.sh
+      contents:
+        inline: |
+          #!/usr/bin/bash
+          echo "Rebasing to uCore OCI in 5 seconds"
+          sleep 5
+          rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/ucore:stable \
+            && touch /etc/ucore-autorebase/.complete \
+            && systemctl disable ucore-autorebase.service \
+            && systemctl reboot
+      mode: 0754
+systemd:
+  units:
+    - name: ucore-autorebase.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=uCore autorebase to OCI and reboot
+        ConditionPathExists=!/etc/ucore-autorebase/.complete
+        ConditionFileIsExecutable=/etc/ucore-autorebase/ucore-autorebase.sh
+        After=network-online.target
+        Wants=network-online.target
+        [Service]
+        Type=oneshot
+        StandardOutput=journal+console
+        RemainAfterExit=yes
+        ExecStart=/etc/ucore-autorebase/ucore-autorebase.sh
+        [Install]
+        WantedBy=multi-user.target


### PR DESCRIPTION
Provide docs and a sample butane file which has been tested to provide a means to autorebase into uCore as part of a new CoreOS installation.

Resolves #3 