### PR TITLE
fix: enable stable builds despite testing failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,7 @@ jobs:
   build_main:
     name: Build uCore
     runs-on: ubuntu-22.04
+    if: ${{ always() }}
     needs: [ build_info, build_zfs ]
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,6 +340,7 @@ jobs:
   build_hci:
     name: Build HCI
     runs-on: ubuntu-22.04
+    if: ${{ always() }}
     needs: [ build_info, build_main ]
     permissions:
       contents: read


### PR DESCRIPTION
Workaround for #21 to enable stable image builds even when testing image builds fail.