### PR TITLE
chore: directly use github for zfs version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,13 @@ jobs:
     steps:
       # Use cURL to fetch the given URL, saving the response to `data.json`
       - name: Fetch zfs versions
-        # Uses project_id from: https://release-monitoring.org/project/11706/
-        run: curl "https://release-monitoring.org/api/v2/versions/?project_id=11706" -o data.json
+        run: curl "https://api.github.com/repos/openzfs/zfs/releases" -o data.json
       - name: Get latest zfs version
         id: latest
-        run: echo "version=$(jq -r '.stable_versions[0]' data.json)" >> $GITHUB_OUTPUT
+        run: echo "version=$(jq -r '.[0].name' data.json)" >> $GITHUB_OUTPUT
       - name: Get previous zfs version
         id: previous
-        run: echo "version=$(jq -r '.stable_versions[1]' data.json)" >> $GITHUB_OUTPUT
+        run: echo "version=$(jq -r '.[1].name' data.json)" >> $GITHUB_OUTPUT
 
   build_zfs:
     name: Build ZFS

--- a/zfs/Containerfile
+++ b/zfs/Containerfile
@@ -22,9 +22,9 @@ RUN dnf install -y jq dkms gcc make autoconf automake libtool rpm-build libtirpc
     python3 python3-devel python3-setuptools python3-cffi libffi-devel git ncompress libcurl-devel
 
 WORKDIR /
-RUN curl -L -O https://github.com/openzfs/zfs/releases/download/zfs-${ZFS_VERSION}/zfs-${ZFS_VERSION}.tar.gz \
-    && tar xzf zfs-${ZFS_VERSION}.tar.gz \
-    && mv zfs-${ZFS_VERSION} /tmp/zfs
+RUN curl -L -O https://github.com/openzfs/zfs/releases/download/${ZFS_VERSION}/${ZFS_VERSION}.tar.gz \
+    && tar xzf ${ZFS_VERSION}.tar.gz \
+    && mv ${ZFS_VERSION} /tmp/zfs
 
 WORKDIR /tmp/zfs
 # build


### PR DESCRIPTION
Fixes #21 a few hours ahead of time since zfs 2.1.10 has been released but release-monitoring.org is not updated yet. Since we just use github releases for zfs anyway, may as well check them directly.