### PR TITLE
fix: stabilize zfs builds

### DIFF
--- a/zfs/Containerfile
+++ b/zfs/Containerfile
@@ -1,37 +1,35 @@
 ARG COREOS_VERSION="${COREOS_VERSION}"
+
+FROM quay.io/fedora/fedora-coreos:${COREOS_VERSION} as builder
+
 ARG ZFS_VERSION="${ZFS_VERSION}"
 
-FROM quay.io/fedora/fedora-coreos:${COREOS_VERSION} as kernel-query
+WORKDIR /tmp
 
 #We can't use the `uname -r` as it will pick up the host kernel version
 RUN rpm -qa kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}' > /kernel-version.txt
 
-# Using https://openzfs.github.io/openzfs-docs/Developer%20Resources/Custom%20Packages.html
-FROM registry.fedoraproject.org/fedora:latest as builder
-ARG ZFS_VERSION="${ZFS_VERSION}"
+# work around to allow alternatives to configure in RPM post-install scripts
+RUN mkdir -p /var/lib/alternatives
 
-COPY --from=kernel-query /kernel-version.txt /kernel-version.txt
-
-WORKDIR /etc/yum.repos.d
-RUN BUILDER_VERSION=$(grep VERSION_ID /etc/os-release | cut -f2 -d=) \
-    && curl -L -O https://src.fedoraproject.org/rpms/fedora-repos/raw/f${BUILDER_VERSION}/f/fedora-updates-archive.repo \
-    && sed -i 's/enabled=AUTO_VALUE/enabled=true/' fedora-updates-archive.repo
-RUN dnf install -y jq dkms gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel \
+RUN rpm-ostree install -y jq dkms gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel \
     libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel \
     kernel-$(cat /kernel-version.txt) kernel-modules-$(cat /kernel-version.txt) kernel-devel-$(cat /kernel-version.txt) \
     python3 python3-devel python3-setuptools python3-cffi libffi-devel git ncompress libcurl-devel
 
-WORKDIR /
-RUN curl -L -O https://github.com/openzfs/zfs/releases/download/${ZFS_VERSION}/${ZFS_VERSION}.tar.gz \
-    && tar xzf ${ZFS_VERSION}.tar.gz \
-    && mv ${ZFS_VERSION} /tmp/zfs
+RUN echo "getting ${ZFS_VERSION}.tar.gz" && \
+    curl -L -O https://github.com/openzfs/zfs/releases/download/${ZFS_VERSION}/${ZFS_VERSION}.tar.gz \
+    && tar xzf ${ZFS_VERSION}.tar.gz
 
-WORKDIR /tmp/zfs
+WORKDIR /tmp/${ZFS_VERSION}
+
 # build
 RUN ./configure \
         -with-linux=/usr/src/kernels/$(cat /kernel-version.txt)/ \
         -with-linux-obj=/usr/src/kernels/$(cat /kernel-version.txt)/ \
-    && make -j 1 rpm-utils rpm-kmod
+    && make -j 1 rpm-utils rpm-kmod \
+    || (cat config.log && exit 1)
+
 # sort into directories for easier install later
 RUN mkdir -p /tmp/rpms/{debug,devel,other,src} \
     && mv *src.rpm /tmp/rpms/src/ \


### PR DESCRIPTION
I investigated continued instability of ZFS builds thinking it could be related to the F38 release. It may have been in a manner of speaking. But I discovered the method of using a Fedora image as a builder was more complex than needed and was the actual culprit.

Switched to using CoreOS image itself as the builder, which primarily required using rpm-ostree (instead of dnf) and the hack to allow alternatives to function (mkdir -p /var/lib/alternatives).