### PR TITLE
fix: change docker-compose installation

### DIFF
--- a/main/Containerfile
+++ b/main/Containerfile
@@ -22,3 +22,5 @@ RUN /tmp/post-install.sh
 RUN rm -rf /tmp/* /var/*
 RUN ostree container commit
 RUN mkdir -p /var/tmp && chmod -R 1777 /var/tmp
+
+COPY --from=docker.io/docker/compose-bin:latest /docker-compose /usr/bin/docker-compose

--- a/main/packages.json
+++ b/main/packages.json
@@ -8,7 +8,6 @@
                 "cockpit-storaged",
                 "cockpit-system",
                 "distrobox",
-                "docker-compose",
                 "duperemove",
                 "firewalld",
                 "podman",


### PR DESCRIPTION
On Fedora 38 (testing) the `docker-compose` RPM is no longer installable. It depends on `python3-dockerpty` which is not maintained and may not be added to the Fedora 38 repos. I've replaced the old python version which was installing from repos with a static binary sourced from docker's official container image for the tool.