### PR TITLE
fix: swap nfs-utils-coreos for nfs-utils

### DIFF
--- a/hci/Containerfile
+++ b/hci/Containerfile
@@ -4,25 +4,19 @@ ARG PR_PREFIX="${PR_PREFIX}"
 
 FROM ghcr.io/ublue-os/${IMAGE_NAME}:${PR_PREFIX}${COREOS_VERSION}
 
+ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
+ARG IMAGE_NAME="${IMAGE_NAME:-ucore}"
+
+
+ADD build.sh /tmp/build.sh
+ADD packages.json /tmp/packages.json
+
 RUN mkdir -p /var/lib/alternatives \
-    && rpm-ostree install \
-        cockpit-machines \
-        libvirt-client \
-        virt-install \
+    && /tmp/build.sh \
     && mv /var/lib/alternatives /staged-alternatives \
     && rm -fr /tmp/* /var/* \
     && rpm-ostree cleanup -m \
     && ostree container commit \
-    && mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives
-
-RUN mkdir -p /var/lib/alternatives \
-    && rpm-ostree install \
-        libvirt-daemon-kvm \
-    && mv /var/lib/alternatives /staged-alternatives \
-    && rm -fr /tmp/* /var/* \
-    && rpm-ostree cleanup -m \
-    && ostree container commit \
-    && mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives
-
-RUN mkdir -p /tmp /var/tmp \
+    && mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives \
+    && mkdir -p /tmp /var/tmp \
     && chmod -R 1777 /tmp /var/tmp

--- a/hci/build.sh
+++ b/hci/build.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+set -ouex pipefail
+
+RELEASE="$(rpm -E %fedora)"
+
+INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+                             (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+                             | sort | unique[]" /tmp/packages.json))
+EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+                             (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+                             | sort | unique[]" /tmp/packages.json))
+
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+fi
+
+if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
+    rpm-ostree install \
+        ${INCLUDED_PACKAGES[@]}
+
+elif [[ "${#INCLUDED_PACKAGES[@]}" -eq 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    rpm-ostree override remove \
+        ${EXCLUDED_PACKAGES[@]}
+
+elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    rpm-ostree override remove \
+        ${EXCLUDED_PACKAGES[@]} \
+        $(printf -- "--install=%s " ${INCLUDED_PACKAGES[@]})
+
+else
+    echo "No packages to install."
+
+fi

--- a/hci/packages.json
+++ b/hci/packages.json
@@ -1,0 +1,18 @@
+{
+    "all": {
+        "include": {
+            "all": [
+                "cockpit-machines",
+                "libvirt-client",
+                "libvirt-daemon-kvm",
+                "nfs-utils",
+                "virt-install"
+            ]
+        },
+        "exclude": {
+            "all": [
+                "nfs-utils-coreos"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
As of F38(new fcos:testing), nfs-utils and nfs-utils-coreos now conflict, where previously they would install at same time despite providing the same files. 

This fixes the problem by removing nfs-utils-coreos and ensuring the installation of nfs-utils.

Switched back to the build.sh/packages.json model for this despite larger image layers as it makes build scripts cleaner.

Fixes: #31 