### PR TITLE
feat: restore toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ WARNING: This image has **not** been heavily tested, though the underlying compo
 `ucore` images:
 
 - Start with a [Fedora CoreOS image](https://quay.io/repository/fedora/fedora-coreos?tab=tags)
-- Remove stock packages:
-  - toolbox
 - Add the following:
   - [cockpit](https://cockpit-project.org)
   - [distrobox](https://github.com/89luca89/distrobox)

--- a/main/packages.json
+++ b/main/packages.json
@@ -22,9 +22,7 @@
             ]
         },
         "exclude": {
-            "all": [
-                "toolbox"
-            ]
+            "all": []
         }
     }
 }


### PR DESCRIPTION
We inherited the removal of toolbox, but I'd rather include to retain CoreOS familiarity unless there is a compelling reason to remove.

fixes: #20