### PR TITLE
fix: enable testing repos on testing stream

### DIFF
--- a/main/Containerfile
+++ b/main/Containerfile
@@ -2,8 +2,8 @@ ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 
 FROM quay.io/fedora/fedora-coreos:${COREOS_VERSION}
 
-ARG IMAGE_NAME="${IMAGE_NAME:-ucore}"
 ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
+ARG IMAGE_NAME="${IMAGE_NAME:-ucore}"
 
 ADD build.sh /tmp/build.sh
 ADD post-install.sh /tmp/post-install.sh
@@ -14,6 +14,16 @@ ARG PR_PREFIX="${PR_PREFIX}"
 COPY --from=ghcr.io/ublue-os/ucore-zfs-rpm:${PR_PREFIX}${COREOS_VERSION} / /tmp/rpms
 COPY etc /etc
 COPY usr /usr
+
+# enable testing repos if not enabled on testing stream
+RUN if [[ "testing" == "${COREOS_VERSION}" ]]; then \
+for REPO in $(ls /etc/yum.repos.d/fedora-updates-testing{,-modular}.repo); do \
+  if [[ "$(grep enabled=1 ${REPO} > /dev/null; echo $?)" == "1" ]]; then \
+    echo "enabling $REPO" &&\
+    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}; \
+  fi; \
+done; \
+fi
 
 # install locally prepared RPMs (ZFS, etc)
 RUN rpm-ostree install /tmp/rpms/*.rpm

--- a/zfs/Containerfile
+++ b/zfs/Containerfile
@@ -2,6 +2,7 @@ ARG COREOS_VERSION="${COREOS_VERSION}"
 
 FROM quay.io/fedora/fedora-coreos:${COREOS_VERSION} as builder
 
+ARG COREOS_VERSION="${COREOS_VERSION}"
 ARG ZFS_VERSION="${ZFS_VERSION}"
 
 WORKDIR /tmp
@@ -11,6 +12,16 @@ RUN rpm -qa kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}' > /kernel-versi
 
 # work around to allow alternatives to configure in RPM post-install scripts
 RUN mkdir -p /var/lib/alternatives
+
+# enable testing repos if not enabled on testing stream
+RUN if [[ "testing" == "${COREOS_VERSION}" ]]; then \
+for REPO in $(ls /etc/yum.repos.d/fedora-updates-testing{,-modular}.repo); do \
+  if [[ "$(grep enabled=1 ${REPO} > /dev/null; echo $?)" == "1" ]]; then \
+    echo "enabling $REPO" &&\
+    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}; \
+  fi; \
+done; \
+fi
 
 RUN rpm-ostree install -y jq dkms gcc make autoconf automake libtool rpm-build libtirpc-devel libblkid-devel \
     libuuid-devel libudev-devel openssl-devel zlib-devel libaio-devel libattr-devel elfutils-libelf-devel \


### PR DESCRIPTION
I had assumed the testing repos were enabled by default on the FCOS testing stream, but it seems they are not. This change enables them, but only after ensuring they are not already enabled. This should correct build failures which occur on testing when packages are being worked on and in testing repos but not yet moved to stable.