### PR TITLE
refactor: reorganize build scripts add repos

### DIFF
--- a/main/Containerfile
+++ b/main/Containerfile
@@ -15,21 +15,7 @@ COPY --from=ghcr.io/ublue-os/ucore-kmods:${COREOS_VERSION} /rpms/ /tmp/rpms
 COPY etc /etc
 COPY usr /usr
 
-# enable testing repos if not enabled on testing stream
-RUN if [[ "testing" == "${COREOS_VERSION}" ]]; then \
-for REPO in $(ls /etc/yum.repos.d/fedora-updates-testing{,-modular}.repo); do \
-  if [[ "$(grep enabled=1 ${REPO} > /dev/null; echo $?)" == "1" ]]; then \
-    echo "enabling $REPO" &&\
-    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}; \
-  fi; \
-done; \
-fi
-
-RUN if [[ "-zfs" == "${ZFS_TAG}" ]]; then \
-    rpm-ostree install /tmp/rpms/kmods/zfs/*.rpm; \
-fi; \
-    /tmp/github-release-install.sh trapexit/mergerfs x86_64.rpm fc && \
-    /tmp/build.sh && \
+RUN /tmp/build.sh && \
     /tmp/post-install.sh && \
     rm -rf /tmp/* /var/* && \
     ostree container commit && \

--- a/main/build.sh
+++ b/main/build.sh
@@ -4,14 +4,44 @@ set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
 
+
+#### PREPARE
+# enable testing repos if not enabled on testing stream
+if [[ "testing" == "${COREOS_VERSION}" ]]; then
+for REPO in $(ls /etc/yum.repos.d/fedora-updates-testing{,-modular}.repo); do
+  if [[ "$(grep enabled=1 ${REPO} > /dev/null; echo $?)" == "1" ]]; then
+    echo "enabling $REPO" &&
+    sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}
+  fi
+done
+fi
+
+# always disable cisco-open264 repo
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
+
+# add tailscale repo
+curl -L https://pkgs.tailscale.com/stable/fedora/tailscale.repo -o /etc/yum.repos.d/tailscale.repo
+
+# add rpmfusion (needed for nvidia akmods, etc)
+mkdir -p /tmp/rpms
+rpm-ostree install \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+
+
+#### INSTALL
+## install ZFS if tagged
+if [[ "-zfs" == "${ZFS_TAG}" ]]; then
+    rpm-ostree install /tmp/rpms/kmods/zfs/*.rpm
+fi
+
+## install packages.json stuffs
 INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /tmp/packages.json))
 EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /tmp/packages.json))
-
-curl -L https://pkgs.tailscale.com/stable/fedora/tailscale.repo -o /etc/yum.repos.d/tailscale.repo
 
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
@@ -35,6 +65,6 @@ else
 
 fi
 
-rm -f /etc/yum.repos.d/tailscale.repo
 
-rpm-ostree cleanup -m
+## install packages direct from github
+/tmp/github-release-install.sh trapexit/mergerfs x86_64.rpm fc


### PR DESCRIPTION
This simplifies the Containerfile and moves preparation logic for zfs (and future nvidia) into the build.sh script for simpler scripting. Also adds rpmfusion repos and no longer deletes the tailscale repo.