### PR TITLE
feat: add intel wifi firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Hyper-Coverged Infrastructure(HCI) refers to storage and virtualization in one p
 - Adds the following:
   - [cockpit-machines](https://github.com/cockpit-project/cockpit-machines): Cockpit GUI for managing virtual machines
   - [duperemove](https://github.com/markfasheh/duperemove)
+  - intel wifi firmware - CoreOS omits this despite including atheros wifi firmware... hardware enablement FTW
   - [libvirt-client](https://libvirt.org/): `virsh` command-line utility for managing virtual machines
   - [libvirt-daemon-kvm](https://libvirt.org/): libvirt KVM hypervisor management
   - [mergerfs](https://github.com/trapexit/mergerfs)

--- a/hci/packages.json
+++ b/hci/packages.json
@@ -4,6 +4,9 @@
             "all": [
                 "cockpit-machines",
                 "duperemove",
+                "iwlegacy-firmware",
+                "iwlwifi-dvm-firmware",
+                "iwlwifi-mvm-firmware",
                 "libvirt-client",
                 "libvirt-daemon-kvm",
                 "nfs-utils",


### PR DESCRIPTION
Had a user bring this up in Discord chat. It seemed odd to me that Atheros wifi would work out of the box but not Intel.

Including in `ucore-hci` for hardware enablement, but not in `ucore` to keep with the theme of minimal base/VM image.