### PR TITLE
refactor: ensure packages.json override/replace works

### DIFF
--- a/hci/build.sh
+++ b/hci/build.sh
@@ -4,25 +4,34 @@ set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
 
+## install packages.json stuffs
+# build list of all packages requested for inclusion
 INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /tmp/packages.json))
+
+# build list of all packages requested for exclusion
 EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /tmp/packages.json))
 
+
+# ensure exclusion list only contains packages already present on image
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
 fi
 
+# ensure exclusion list only contains packages already present on image
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+fi
+
+# simple case to install where no packages need excluding
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
     rpm-ostree install \
         ${INCLUDED_PACKAGES[@]}
 
-elif [[ "${#INCLUDED_PACKAGES[@]}" -eq 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
-        ${EXCLUDED_PACKAGES[@]}
-
+# install/excluded packages both at same time
 elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     rpm-ostree override remove \
         ${EXCLUDED_PACKAGES[@]} \
@@ -31,6 +40,22 @@ elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]];
 else
     echo "No packages to install."
 
+fi
+
+# check if any excluded packages are still present
+# (this can happen if an included package pulls in a dependency)
+EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+                             (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+                             | sort | unique[]" /tmp/packages.json))
+
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+fi
+
+# remove any excluded packages which are still present on image
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    rpm-ostree override remove \
+        ${EXCLUDED_PACKAGES[@]}
 fi
 
 

--- a/main/build.sh
+++ b/main/build.sh
@@ -42,25 +42,33 @@ if [[ "-zfs" == "${ZFS_TAG}" ]]; then
 fi
 
 ## install packages.json stuffs
+# build list of all packages requested for inclusion
 INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /tmp/packages.json))
+
+# build list of all packages requested for exclusion
 EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /tmp/packages.json))
 
+
+# ensure exclusion list only contains packages already present on image
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
 fi
 
+# ensure exclusion list only contains packages already present on image
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+fi
+
+# simple case to install where no packages need excluding
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
     rpm-ostree install \
         ${INCLUDED_PACKAGES[@]}
 
-elif [[ "${#INCLUDED_PACKAGES[@]}" -eq 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
-        ${EXCLUDED_PACKAGES[@]}
-
+# install/excluded packages both at same time
 elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     rpm-ostree override remove \
         ${EXCLUDED_PACKAGES[@]} \
@@ -69,4 +77,20 @@ elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]];
 else
     echo "No packages to install."
 
+fi
+
+# check if any excluded packages are still present
+# (this can happen if an included package pulls in a dependency)
+EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+                             (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+                             | sort | unique[]" /tmp/packages.json))
+
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+fi
+
+# remove any excluded packages which are still present on image
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    rpm-ostree override remove \
+        ${EXCLUDED_PACKAGES[@]}
 fi


### PR DESCRIPTION
Changes the build.sh logic for packages.json so one can remove (exclude) a dependent package which is installed by an included package. Also handle the case where an include/exclude combo results in an override replace operation.

