### PR TITLE
fix: enable ublue-nvctk-cdi by default for nvidia images

### DIFF
--- a/main/post-install.sh
+++ b/main/post-install.sh
@@ -12,6 +12,8 @@ if [[ "-nvidia" == "${NVIDIA_TAG}" ]]; then
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/nvidia-container-toolkit.repo
 
     semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
+
+    systemctl enable ublue-nvctk-cdi.service
 fi
 
 


### PR DESCRIPTION
Had this problem on the desktop universal blue nvidia images also. The systemd service preset is not enough to ensure a service is enabled after rebasing to an image containing it. So the service must be explicitly enabled.

Fixes: #102