### PR TITLE
fix: run depmod after installing ZFS RPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A generic [Fedora CoreOS image](https://quay.io/repository/fedora/fedora-coreos?
   - [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/sample-workload.html) - latest toolkit which supports both root and rootless podman containers and CDI
   - [nvidia container selinux policy](https://github.com/NVIDIA/dgx-selinux/tree/master/src/nvidia-container-selinux) - allows using `--security-opt label=type:nvidia_container_t` for some jobs (some will still need `--security-opt label=disable` as suggested by nvidia)
 - [ZFS versions](#tag-matrix) add:
-  - [ZFS driver](https://github.com/ublue-os/ucore-kmods) - latest driver (currently pinned to 2.1.x series)
+  - [ZFS driver](https://github.com/ublue-os/ucore-kmods) - latest driver (currently pinned to 2.2.x series)
 
 *NOTE: currently, zincati fails to start on systems with OCI based deployments (like uCore). Upstream efforts are active to correct this.*
 
@@ -48,7 +48,7 @@ Suitable for running containerized workloads on either baremetal or virtual mach
   - [nvidia container selinux policy](https://github.com/NVIDIA/dgx-selinux/tree/master/src/nvidia-container-selinux) - allows using `--security-opt label=type:nvidia_container_t` for some jobs (some will still need `--security-opt label=disable` as suggested by nvidia)
 - Optional [ZFS versions](#tag-matrix) add:
   - [sanoid/syncoid dependencies](https://github.com/jimsalterjrs/sanoid) - [see below](#zfs) for details
-  - [ZFS driver](https://github.com/ublue-os/ucore-kmods) - latest driver (currently pinned to 2.1.x series)
+  - [ZFS driver](https://github.com/ublue-os/ucore-kmods) - latest driver (currently pinned to 2.2.x series)
 - Enables staging of automatic system updates via rpm-ostreed
 - Enables password based SSH auth (required for locally running cockpit web interface)
 - Disables Zincati auto upgrade/reboot service

--- a/fedora-coreos/install.sh
+++ b/fedora-coreos/install.sh
@@ -3,6 +3,7 @@
 set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 
 #### PREPARE
 # enable testing repos if not enabled on testing stream
@@ -25,6 +26,8 @@ find /tmp/rpms/
 ## CONDITIONAL: install ZFS (and sanoid deps)
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     rpm-ostree install pv /tmp/rpms/zfs/*.rpm
+    # for some reason depmod ran automatically with zfs 2.1 but not with 2.2
+    depmod -A ${KERNEL}
 fi
 
 ## CONDITIONAL: install NVIDIA

--- a/main/install.sh
+++ b/main/install.sh
@@ -2,6 +2,7 @@
 
 set -ouex pipefail
 
+KERNEL="$(rpm -q kernel --queryformat '%{VERSION}-%{RELEASE}.%{ARCH}')"
 RELEASE="$(rpm -E %fedora)"
 
 #### PREPARE
@@ -22,6 +23,7 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 # inspect to see what RPMS we copied in
 find /tmp/rpms/
 
+
 ## CONDITIONAL: install ZFS (and sanoid deps)
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     rpm-ostree install /tmp/rpms/zfs/*.rpm \
@@ -32,6 +34,8 @@ if [[ "-zfs" == "${ZFS_TAG}" ]]; then
       perl-Config-IniFiles \
       perl-Getopt-Long \
       pv
+    # for some reason depmod ran automatically with zfs 2.1 but not with 2.2
+    depmod -A ${KERNEL}
 fi
 
 ## CONDITIONAL: install NVIDIA


### PR DESCRIPTION
With zfs 2.1.x, this happened automatically. Though unclear why, it no longer seems to occur when installing the zfs 2.2.x RPMs in a container build (it does still work automatically on a non image-based Fedora system).

Manually running depmod, as in this commit, ensures the 2.2.x kmods load as expected.

Fixes: #88 