### PR TITLE
feat: add package with secure boot public signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Users may use [distrobox](https://github.com/89luca89/distrobox) to run images o
 
 It's a good idea to become familar with the [Fedora CoreOS Documentation](https://docs.fedoraproject.org/en-US/fedora-coreos/) as well as the [CoreOS rpm-ostree docs](https://coreos.github.io/rpm-ostree/). Note especially, this image is only possible due to [ostree native containers](https://coreos.github.io/rpm-ostree/container/).
 
+
 ### Sanoid/Syncoid
 
 sanoid/syncoid is a great tool for manual and automated snapshot/transfer of ZFS datasets. However, there is not a current stable RPM, rather they provide [instructions on installing via git](https://github.com/jimsalterjrs/sanoid/blob/master/INSTALL.md#centos).
@@ -162,6 +163,19 @@ If you do forget to specify the mountpoint, or you need to change the mountpoint
 ```
 # zfs set mountpoint=/var/tank tank
 ```
+
+
+### SecureBoot
+
+For those wishing to use the `nvidia` image with a pre-build kmod AND run SecureBoot, the kmod will not be loaded by the kernel until the public signing key has been imported as a MOK (Machine-Owner Key).
+
+Do so like this:
+```bash
+sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der
+```
+
+The utility will prompt for a password. The password will be used to verify this key is the one you meant to import, after rebooting and entering the UEFI MOK import utility.
+
 
 ## How to Install
 

--- a/main/Containerfile
+++ b/main/Containerfile
@@ -10,6 +10,7 @@ ARG NVIDIA_TAG="${NVIDIA_TAG}"
 ARG ZFS_TAG="${ZFS_TAG}"
 ARG KMOD_SRC="${KMOD_SRC:-ghcr.io/ublue-os/ucore-kmods:${COREOS_VERSION}}"
 
+COPY --from=${KMOD_SRC} /rpms/kmods/*.rpm /tmp/rpms/
 COPY --from=${KMOD_SRC} /rpms/kmods/nvidia/*.rpm /tmp/rpms/nvidia/
 COPY --from=${KMOD_SRC} /rpms/kmods/zfs/*.rpm /tmp/rpms/zfs/
 

--- a/main/install.sh
+++ b/main/install.sh
@@ -23,6 +23,7 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 # inspect to see what RPMS we copied in
 find /tmp/rpms/
 
+rpm-ostree install /tmp/rpms/ublue-os-ucore-addons-*.rpm
 
 ## CONDITIONAL: install ZFS (and sanoid deps)
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then


### PR DESCRIPTION
Add the new package from `ucore-kmods` which includes the signing key. This enables a user to import the signing key as a MOK using:

sudo mokutil --import /etc/pki/akmods/certs/akmods-ublue.der

Closes #82