### PR TITLE
chore(ci): resume use of latest tag for stable image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,6 +282,10 @@ jobs:
 
               alias_tags=("${COMMIT_TAGS[@]}")
           else
+              if [[ "$[COREOS_VERSION]" == "stable" ]]; then
+                  BUILD_TAGS+=("latest")
+              fi
+
               alias_tags=("${BUILD_TAGS[@]}")
           fi
 


### PR DESCRIPTION
I intentionally stopped publishing a `:latest` tag back on April 1st. It was not intended to be an April Fool's joke, but rather a cleanup to best practices of not using that tag. However, the old images did not expire, so the old `:latest` continues to exist, confusing both users and our website's image discovery code.

I suppose it turned out to be a long lived April Fool's joke after all!

This resumes the publishing of the tag, ensuring it matches the `:stable` tag, and only on the `ucore` image. There will be no `:latest` for nvidia, zfs or testing images, nor `fedora-coreos` or `ucore-hci`.