### PR TITLE
feat: ucore/packages.json: Add NetworkManager-wifi

### DIFF
--- a/ucore/packages.json
+++ b/ucore/packages.json
@@ -19,6 +19,7 @@
                 "wireguard-tools"
             ],
             "ucore": [
+                "NetworkManager-wifi",
                 "atheros-firmware",
                 "brcmfmac-firmware",
                 "cockpit-pcp",


### PR DESCRIPTION
Add NetworkManager-wifi for a better wifi management experience.

---

Based on https://github.com/ublue-os/ucore/pull/139 for convenience.

See: https://github.com/ublue-os/ucore/issues/138
See: https://github.com/coreos/fedora-coreos-tracker/issues/862