### PR TITLE
feat: add hdparm to ucore

### DIFF
--- a/ucore/packages.json
+++ b/ucore/packages.json
@@ -23,6 +23,7 @@
                 "cockpit-storaged",
                 "distrobox",
                 "duperemove",
+                "hdparm",
                 "iwlegacy-firmware",
                 "iwlwifi-dvm-firmware",
                 "iwlwifi-mvm-firmware",


### PR DESCRIPTION
This adds hdparm to ucore & ucore-hci, but not ucore-minimal.

User package request seems quite reasonable.

Closes: #137