### PR TITLE
feat: install docker-compose as cli plugin, add buildx

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Suitable for running containerized workloads on either bare metal or virtual mac
   - [cockpit](https://cockpit-project.org) (podman container and system management)
   - [firewalld](https://firewalld.org/)
   - guest VM agents (`qemu-guest-agent` and `open-vm-tools`))
-  - [docker-compose](https://github.com/docker/compose) and [podman-compose](https://github.com/containers/podman-compose) *docker(moby-engine) and podman are pre-installed in CoreOS*
+  - [docker-buildx](https://github.com/docker/buildx) and [docker-compose](https://github.com/docker/compose) (versions matched to moby release) *docker(moby-engine) is pre-installed in CoreOS*
+  - [podman-compose](https://github.com/containers/podman-compose) *podman is pre-installed in CoreOS*
   - [tailscale](https://tailscale.com) and [wireguard-tools](https://www.wireguard.com)
   - [tmux](https://github.com/tmux/tmux/wiki/Getting-Started)
   - udev rules enabling full functionality on some [Realtek 2.5Gbit USB Ethernet](https://github.com/wget/realtek-r8152-linux/) devices

--- a/ucore/Containerfile
+++ b/ucore/Containerfile
@@ -11,6 +11,11 @@ ARG NVIDIA_TAG="${NVIDIA_TAG}"
 ARG ZFS_TAG="${ZFS_TAG}"
 ARG KMOD_SRC="${KMOD_SRC:-ghcr.io/ublue-os/ucore-kmods:${COREOS_VERSION}}"
 
+# 0.12.1 matches docker/moby 24.0.5 which FCOS ships as of 40.20240421
+ARG DOCKER_BUILDX_VERSION=0.12.1
+# 2.24.7 matches docker/moby 24.0.5  which FCOS ships as of 40.20240421
+ARG DOCKER_COMPOSE_VERSION=v2.24.7
+
 COPY --from=${KMOD_SRC} /rpms/kmods/*.rpm /tmp/rpms/
 COPY --from=${KMOD_SRC} /rpms/kmods/nvidia/*.rpm /tmp/rpms/nvidia/
 COPY --from=${KMOD_SRC} /rpms/kmods/zfs/*.rpm /tmp/rpms/zfs/
@@ -30,7 +35,16 @@ RUN mkdir -p /var/lib/alternatives \
     && mkdir -p /tmp /var/tmp \
     && chmod -R 1777 /tmp /var/tmp
 
-COPY --from=docker.io/docker/compose-bin:latest /docker-compose /usr/bin/docker-compose
+COPY --from=docker.io/docker/buildx-bin:${DOCKER_BUILDX_VERSION} /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker.io/docker/compose-bin:${DOCKER_COMPOSE_VERSION} /docker-compose /usr/libexec/docker/cli-plugins/docker-compose
+
+RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose \
+    && mv /var/lib/alternatives /staged-alternatives \
+    && rm -fr /tmp/* /var/* \
+    && ostree container commit \
+    && mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives \
+    && mkdir -p /tmp /var/tmp \
+    && chmod -R 1777 /tmp /var/tmp
 
 
 # ucore image section


### PR DESCRIPTION
Some users had noticed that `docker-compose` was not usable as a plugin (eg, `docker compose`). This fixes that by installing it the way moby does upstream, plus adds `docker-buildx`. Both are versioned now rather than being `latest`, and version matched to the moby release.

Note: this is a minor downgrade of `docker-compose` from `v2.26.1` to `v2.24.7`.

As of this writing, FCOS next is still on moby 24.0.5. 
Some details on versions:
- https://fedoraproject.org/coreos/release-notes?arch=x86_64&stream=testing
- https://github.com/docker/buildx/releases
- https://github.com/docker/compose/releases

Closes: #141