### PR TITLE
feat: Added rebasing to a signed image

### DIFF
--- a/examples/ucore-autorebase.butane
+++ b/examples/ucore-autorebase.butane
@@ -10,33 +10,41 @@ storage:
   directories:
     - path: /etc/ucore-autorebase
       mode: 0754
-  files:
-    - path: /etc/ucore-autorebase/ucore-autorebase.sh
-      contents:
-        inline: |
-          #!/usr/bin/bash
-          echo "Rebasing to uCore OCI in 5 seconds"
-          sleep 5
-          rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/ucore:stable \
-            && touch /etc/ucore-autorebase/.complete \
-            && systemctl disable ucore-autorebase.service \
-            && systemctl reboot
-      mode: 0754
 systemd:
   units:
-    - name: ucore-autorebase.service
+    - name: ucore-unsigned-autorebase.service
       enabled: true
       contents: |
         [Unit]
-        Description=uCore autorebase to OCI and reboot
-        ConditionPathExists=!/etc/ucore-autorebase/.complete
-        ConditionFileIsExecutable=/etc/ucore-autorebase/ucore-autorebase.sh
+        Description=uCore autorebase to unsigned OCI and reboot
+        ConditionPathExists=!/etc/ucore-autorebase/unverified
+        ConditionPathExists=!/etc/ucore-autorebase/signed
         After=network-online.target
         Wants=network-online.target
         [Service]
         Type=oneshot
         StandardOutput=journal+console
-        RemainAfterExit=yes
-        ExecStart=/etc/ucore-autorebase/ucore-autorebase.sh
+        ExecStart=/usr/bin/rpm-ostree rebase --bypass-driver ostree-unverified-registry:ghcr.io/ublue-os/ucore:stable
+        ExecStart=/usr/bin/touch /etc/ucore-autorebase/unverified
+        ExecStart=/usr/bin/systemctl disable ucore-unsigned-autorebase.service
+        ExecStart=/usr/bin/systemctl reboot
+        [Install]
+        WantedBy=multi-user.target
+    - name: ucore-signed-autorebase.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=uCore autorebase to signed OCI and reboot
+        ConditionPathExists=/etc/ucore-autorebase/unverified
+        ConditionPathExists=!/etc/ucore-autorebase/verified
+        After=network-online.target
+        Wants=network-online.target
+        [Service]
+        Type=oneshot
+        StandardOutput=journal+console
+        ExecStart=/usr/bin/rpm-ostree rebase --bypass-driver ostree-image-signed:docker://ghcr.io/ublue-os/ucore:stable
+        ExecStart=/usr/bin/touch /etc/ucore-autorebase/signed
+        ExecStart=/usr/bin/systemctl disable ucore-signed-autorebase.service
+        ExecStart=/usr/bin/systemctl reboot
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
1. I moved the logic from `ucore-autorebase.sh` into the service itself, to minimize leftover files.
2. I also added another service to rebase to the signed image, after the initial rebase-and-reboot, just like [blue-build/template](https://github.com/blue-build/template) recommends in the README.
3. I ripped out `RemainAfterExit=yes` since i couldn't figure out why it was needed.
4. I added `--bypass-driver` to the rebase commands to bypass this error: (building on ucore-minimal)
```
Apr 25 19:50:33 localhost.localdomain rpm-ostree[1846]: error: Updates and deployments are driven by Zincati (zincati.service)
Apr 25 19:50:33 localhost.localdomain rpm-ostree[1846]: See Zincati's documentation at https://github.com/coreos/zincati
Apr 25 19:50:33 localhost.localdomain rpm-ostree[1846]: Use --bypass-driver to bypass Zincati and perform the operation anyways
```
I'm not sure if that is the best way to handle it? 
I'm guessing Zincati should be completely disabled since it isn't compatible with OCI images, but haven't gotten that far into the weeds yet.

PS.: I redid my contribution to pass the automated test. I'm sorry if i spammed someones indbox.