### PR TITLE
fix: symlink ldconfig to ldconfig.real for gpu-operator support

### DIFF
--- a/ucore/Containerfile
+++ b/ucore/Containerfile
@@ -39,6 +39,7 @@ COPY --from=docker.io/docker/buildx-bin:${DOCKER_BUILDX_VERSION} /buildx /usr/li
 COPY --from=docker.io/docker/compose-bin:${DOCKER_COMPOSE_VERSION} /docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 
 RUN ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose \
+    && ln -s /sbin/ldconfig /sbin/ldconfig.real \
     && mv /var/lib/alternatives /staged-alternatives \
     && rm -fr /tmp/* /var/* \
     && ostree container commit \


### PR DESCRIPTION
Currently Nvidia's GPU Operator expects `ldconfig.real` to exist. See https://github.com/NVIDIA/nvidia-container-toolkit/issues/147 for more info.

Short-term you _can_ modify `/usr/local/nvidia/toolkit/.config/nvidia-container-runtime/config.toml` to point to `/sbin/ldconfig` however any time the pods cycle or the node reboots it regenerates the file and points to the incorrect ldconfig.