### PR TITLE
fix: remove wget/wget2 package

### DIFF
--- a/ucore/packages.json
+++ b/ucore/packages.json
@@ -15,7 +15,6 @@
                 "qemu-guest-agent",
                 "tailscale",
                 "tmux",
-                "wget",
                 "wireguard-tools"
             ],
             "ucore": [


### PR DESCRIPTION
CoreOS testing stream has already moved to Fedora 40, which sadly swapped wget for wget2 which was not an actual replacment.

See issues:
- https://gitlab.com/gnuwget/wget2/-/issues/661
- https://github.com/rockdaboot/wget2/issues/314

Given the current situation, this package will be removed from ucore until further notice.