### PR TITLE
fix: add coreos pool repo to mitigate dependancy build issue

### DIFF
--- a/ucore/install-ucore-hci.sh
+++ b/ucore/install-ucore-hci.sh
@@ -2,9 +2,15 @@
 
 set -ouex pipefail
 
+# add the coreos pool repo for package versions which can't be found elswehere
+curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo -o /etc/yum.repos.d/fedora-coreos-pool.repo
+
 # install packages.json stuffs
 export IMAGE_NAME=ucore-hci
 /tmp/packages.sh
+
+# remove coreos pool repo
+rm -f /etc/yum.repos.d/fedora-coreos-pool.repo
 
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore HCI)"/' /usr/lib/os-release


### PR DESCRIPTION
For over a week, the libvirt-client package has required a version of gnu-tls not available for install. This fixes by granting access to the coreos pool repo which caches versions of packages used in FCOS even if they are no longer present in other Fedora repos.