### PR TITLE
fix: use fedora release for mergerfs install

### DIFF
--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -2,6 +2,8 @@
 
 set -ouex pipefail
 
+RELEASE="$(rpm -E %fedora)"
+
 ## CONDITIONAL: install sanoid if ZFS
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     rpm-ostree install sanoid
@@ -12,7 +14,7 @@ export IMAGE_NAME=ucore
 /tmp/packages.sh
 
 # install packages direct from github
-/tmp/github-release-install.sh trapexit/mergerfs fc.x86_64
+/tmp/github-release-install.sh trapexit/mergerfs fc${RELEASE}.x86_64
 
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore)"/' /usr/lib/os-release


### PR DESCRIPTION
mergerfs chagned naming on their RPMs to be more specific.

This catches up to that change.

Fixes: #157