### PR TITLE
fix: do not install pre-release packages

### DIFF
--- a/ucore/install-ucore-hci.sh
+++ b/ucore/install-ucore-hci.sh
@@ -2,15 +2,9 @@
 
 set -ouex pipefail
 
-# add the coreos pool repo for package versions which can't be found elswehere
-curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo -o /etc/yum.repos.d/fedora-coreos-pool.repo
-
 # install packages.json stuffs
 export IMAGE_NAME=ucore-hci
 /tmp/packages.sh
-
-# remove coreos pool repo
-rm -f /etc/yum.repos.d/fedora-coreos-pool.repo
 
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore HCI)"/' /usr/lib/os-release

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -26,10 +26,6 @@ curl -L https://copr.fedorainfracloud.org/coprs/ublue-os/ucore/repo/fedora/ublue
 # always disable cisco-open264 repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 
-# required for some package versions on coreos
-curl -L -o /etc/yum.repos.d/fedora-coreos-pool.repo \
-    https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo
-
 #### INSTALL
 # inspect to see what RPMS we copied in
 find /tmp/rpms/
@@ -88,6 +84,3 @@ export IMAGE_NAME=ucore-minimal
 
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/"$/ (uCore minimal)"/' /usr/lib/os-release
-
-# remove after installing coreos packages
-rm -f /etc/yum.repos.d/fedora-coreos-pool.repo


### PR DESCRIPTION
Two previous changes had added the fedora-coreos-pool.repo to mitigate build issues with slightly older CoreOS RPM dependencies no longer being available during builds of uCore. This was done without any prioritization changes, and initially worked fine as Fedora 40 was the newest release in the repo. Now it seems Fedora 41 packages are making their way into the uCore images, which was NOT intended and not desired. This removes that repo.

If it is ever needed again, will need to investigate deprioritizing so normal repos are used except for missing packages.

Fixes: #174

Relates: #163
Relates: #167