### PR TITLE
improve: sanoid should install on minimal if zfs

### DIFF
--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -59,6 +59,11 @@ if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     depmod -A ${KERNEL_VERSION}
 fi
 
+## CONDITIONAL: install sanoid if ZFS
+if [[ "-zfs" == "${ZFS_TAG}" ]]; then
+    rpm-ostree install sanoid
+fi
+
 ## CONDITIONAL: install NVIDIA
 if [[ "-nvidia" == "${NVIDIA_TAG}" ]]; then
     # repo for nvidia rpms

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -52,15 +52,12 @@ else
         /tmp/rpms/kernel/kernel-modules-*.rpm
 fi
 
-## CONDITIONAL: install ZFS (and sanoid deps)
+## CONDITIONAL: install ZFS (and sanoid with deps)
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     rpm-ostree install pv /tmp/rpms/akmods-zfs/kmods/zfs/*.rpm
     # for some reason depmod ran automatically with zfs 2.1 but not with 2.2
     depmod -A ${KERNEL_VERSION}
-fi
-
-## CONDITIONAL: install sanoid if ZFS
-if [[ "-zfs" == "${ZFS_TAG}" ]]; then
+    
     rpm-ostree install sanoid
 fi
 

--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -4,11 +4,6 @@ set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
 
-## CONDITIONAL: install sanoid if ZFS
-if [[ "-zfs" == "${ZFS_TAG}" ]]; then
-    rpm-ostree install sanoid
-fi
-
 # install packages.json stuffs
 export IMAGE_NAME=ucore
 /ctx/packages.sh


### PR DESCRIPTION
We should have sanoid available in minimal, since we already allow for the dependencies to be installed and zfs is an option for use. 