### PR TITLE
feat: updated cockpit-bridge obsoletes cockpit-pcp

### DIFF
--- a/ucore/packages.json
+++ b/ucore/packages.json
@@ -23,7 +23,6 @@
                 "NetworkManager-wifi",
                 "atheros-firmware",
                 "brcmfmac-firmware",
-                "cockpit-pcp",
                 "cockpit-storaged",
                 "distrobox",
                 "duperemove",


### PR DESCRIPTION
This removes the cockpit-pcp package as it's no longer required. The functionality was implemented within cockpit-bridge which is already installed.

See: https://cockpit-project.org/blog/cockpit-326.html

Fixes builds of ucore/ucore-hci.