### PR TITLE
chore: temporarily pause stable scheduled builds

### DIFF
--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -1,9 +1,11 @@
 name: stable
 on:
-  pull_request:
   merge_group:
-  schedule:
-    - cron: '50 2 * * *'  # 2:50am-ish UTC everyday (approx 45 minutes after akmods images run)
+  pull_request:
+    branches:
+      -main
+  #schedule:
+  #  - cron: '50 2 * * *'  # 2:50am-ish UTC everyday (approx 45 minutes after akmods images run)
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -3,7 +3,7 @@ on:
   merge_group:
   pull_request:
     branches:
-      -main
+      - main
   #schedule:
   #  - cron: '50 2 * * *'  # 2:50am-ish UTC everyday (approx 45 minutes after akmods images run)
   workflow_dispatch:

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -1,7 +1,9 @@
 name: testing
 on:
-  pull_request:
   merge_group:
+  pull_request:
+    branches:
+      -main
   schedule:
     - cron: '55 2 * * *'  # 2:55am-ish UTC everyday (approx 50 minutes after akmods images run)
   workflow_dispatch:

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -3,7 +3,7 @@ on:
   merge_group:
   pull_request:
     branches:
-      -main
+      - main
   schedule:
     - cron: '55 2 * * *'  # 2:55am-ish UTC everyday (approx 50 minutes after akmods images run)
   workflow_dispatch:


### PR DESCRIPTION
This is a safety measure to avoid upgrading to kernel 6.11.5 which will break tailscale status and likely cause bug reports.

CoreOS images updated stable to F41 this morning... however, it now uses kernel 6.11.5 which has a known bug which (IMHO is a pretty bad typo) breaks tailscale status reporting https://github.com/tailscale/tailscale/issues/13863 (Note: I do believe tailscale connectivity still works on this kernel, only status reporting is broken.)