### PR TITLE
fix: possible fix for apparent ZFS depmod fail

### DIFF
--- a/fedora-coreos/install.sh
+++ b/fedora-coreos/install.sh
@@ -53,7 +53,7 @@ fi
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     rpm-ostree install pv /tmp/rpms/akmods-zfs/kmods/zfs/*.rpm /tmp/rpms/akmods-zfs/kmods/zfs/other/zfs-dracut-*.rpm
     # for some reason depmod ran automatically with zfs 2.1 but not with 2.2
-    depmod -A ${KERNEL_VERSION}
+    depmod -a -v ${KERNEL_VERSION}
 fi
 
 ## CONDITIONAL: install NVIDIA

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -56,7 +56,7 @@ fi
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     rpm-ostree install pv /tmp/rpms/akmods-zfs/kmods/zfs/*.rpm /tmp/rpms/akmods-zfs/kmods/zfs/other/zfs-dracut-*.rpm
     # for some reason depmod ran automatically with zfs 2.1 but not with 2.2
-    depmod -A ${KERNEL_VERSION}
+    depmod -a -v ${KERNEL_VERSION}
 fi
 
 ## CONDITIONAL: install NVIDIA


### PR DESCRIPTION
There is a difference in how Bluefin and uCore run depmod, so I'm trying their method as that seems to at least not hurt, and may resolve this.

I did test a locally built image with these changes in a VM. It helped, but then I reverted them and I couldn't reproduce the problem at all, so the results seemed positive but inconclusive.

Relates: #210