### PR TITLE
fix: restore mergerfs in f41

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Please take a look at the included modifications, and help us improve uCore if t
 
 ## Announcements
 
+### 2024.11.14 - mergerfs not yet available on Fedora 41
+
+It turns out mergerfs packages are not being built yet for Fedora 41, so it is missing from uCore at this time. It will be restored when possible.
+
 ### 2024.11.12 - uCore has updated to Fedora 41
 
 As of today our upstream Fedora CoreOS stable image updated to Fedora 41 under the hood, so expect a lot of package updates.
@@ -135,7 +139,7 @@ This image builds on `ucore-minimal` but adds drivers, storage tools and utiliti
   - [distrobox](https://github.com/89luca89/distrobox) - a [toolbox](https://containertoolbx.org/) alternative
   - [duperemove](https://github.com/markfasheh/duperemove)
   - all wireless (wifi) card firmwares (CoreOS does not include them) - hardware enablement FTW
-  - [mergerfs](https://github.com/trapexit/mergerfs)
+  - ~~[mergerfs](https://github.com/trapexit/mergerfs)~~ (missing since Fedora 41 update)
   - nfs-utils - nfs utils including daemon for kernel NFS server
   - [pcp](https://pcp.io) Performance Co-pilot monitoring
   - [rclone](https://www.rclone.org/) - file synchronization and mounting of cloud storage

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ Please take a look at the included modifications, and help us improve uCore if t
 
 ## Announcements
 
-### 2024.11.14 - mergerfs not yet available on Fedora 41
-
-It turns out mergerfs packages are not being built yet for Fedora 41, so it is missing from uCore at this time. It will be restored when possible.
-
 ### 2024.11.12 - uCore has updated to Fedora 41
 
 As of today our upstream Fedora CoreOS stable image updated to Fedora 41 under the hood, so expect a lot of package updates.
@@ -139,7 +135,7 @@ This image builds on `ucore-minimal` but adds drivers, storage tools and utiliti
   - [distrobox](https://github.com/89luca89/distrobox) - a [toolbox](https://containertoolbx.org/) alternative
   - [duperemove](https://github.com/markfasheh/duperemove)
   - all wireless (wifi) card firmwares (CoreOS does not include them) - hardware enablement FTW
-  - ~~[mergerfs](https://github.com/trapexit/mergerfs)~~ (missing since Fedora 41 update)
+  - [mergerfs](https://github.com/trapexit/mergerfs)
   - nfs-utils - nfs utils including daemon for kernel NFS server
   - [pcp](https://pcp.io) Performance Co-pilot monitoring
   - [rclone](https://www.rclone.org/) - file synchronization and mounting of cloud storage

--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -14,7 +14,8 @@ export IMAGE_NAME=ucore
 /ctx/packages.sh
 
 # install packages direct from github
-/ctx/github-release-install.sh trapexit/mergerfs fc${RELEASE}.x86_64
+# Fedora 41 packages missing for mergerfs
+#/ctx/github-release-install.sh trapexit/mergerfs fc${RELEASE}.x86_64
 
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore)"/' /usr/lib/os-release

--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -16,6 +16,13 @@ export IMAGE_NAME=ucore
 # install packages direct from github
 # Fedora 41 packages missing for mergerfs
 #/ctx/github-release-install.sh trapexit/mergerfs fc${RELEASE}.x86_64
+curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL -o /tmp/mfs-api.json \
+    "https://api.github.com/repos/trapexit/mergerfs/releases/latest"
+MFS_TGZ_URL=$(cat /tmp/mfs-api.json | \
+    jq -r --arg arch_filter "linux_amd64" \
+    '.assets | sort_by(.created_at) | reverse | .[] | select(.name|test($arch_filter)) | select (.name|test("tar.gz$")) | .browser_download_url')
+curl -sSL -o /tmp/mergerfs.tar.gz ${MFS_TGZ_URL}
+tar -zxvf /tmp/mergerfs.tar.gz -C /usr --strip-components=2
 
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore)"/' /usr/lib/os-release

--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -21,7 +21,7 @@ curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL -o /tmp/mfs-api.js
 MFS_TGZ_URL=$(cat /tmp/mfs-api.json | \
     jq -r --arg arch_filter "linux_amd64" \
     '.assets | sort_by(.created_at) | reverse | .[] | select(.name|test($arch_filter)) | select (.name|test("tar.gz$")) | .browser_download_url')
-curl -sSL -o /tmp/mergerfs.tar.gz ${MFS_TGZ_URL}
+curl -sSL -o /tmp/mergerfs.tar.gz "${MFS_TGZ_URL}"
 tar -zxvf /tmp/mergerfs.tar.gz -C /usr --strip-components=2
 
 # tweak os-release


### PR DESCRIPTION
Instead of documenting its absence, let's ensure mergerfs is present!

This isn't installed via RPM but at least it's there.

Fixes: #214 