### PR TITLE
fix: github release install silently fails if no urls found

### DIFF
--- a/ucore/github-release-install.sh
+++ b/ucore/github-release-install.sh
@@ -47,14 +47,11 @@ API="https://api.github.com/repos/${ORG_PROJ}/releases/${RELTAG}"
 
 # retry up to 5 times with 5 second delays for any error included HTTP 404 etc
 curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL ${API} -o ${API_JSON}
-RPM_URLS=$(cat ${API_JSON} \
+RPM_URLS=($(cat ${API_JSON} \
   | jq \
     -r \
     --arg arch_filter "${ARCH_FILTER}" \
-    '.assets | sort_by(.created_at) | reverse | .[] | select(.name|test($arch_filter)) | select (.name|test("rpm$")) | .browser_download_url')
-for URL in ${RPM_URLS}; do
-  # WARNING: in case of multiple matches, this only installs the first matched release
-  echo "execute: rpm-ostree install \"${URL}\""
-  rpm-ostree install "${URL}"
-  break
-done
+    '.assets | sort_by(.created_at) | reverse | .[] | select(.name|test($arch_filter)) | select(.name|test("rpm$")) | .browser_download_url'))
+# WARNING: in case of multiple matches, this only installs the first matched release
+echo "execute: rpm-ostree install \"${RPM_URLS[0]}\""
+rpm-ostree install "${RPM_URLS[0]}"


### PR DESCRIPTION
This copies the fix from ublue-os/main#571 to ensure that the github release install script fails properly when nothing matches the filter.

The bug fixed by this also relates to ublue-os/ucore#214 since that kind of bug report will be caught by build failures in the future, thanks to this fix.

Thanks to @bcook254 for the solution in the ublue-os/main#571 PR.