### PR TITLE
chore(ci): don't run ci for markdown changes

### DIFF
--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   schedule:
     - cron: '50 2 * * *'  # 2:50am-ish UTC everyday (approx 45 minutes after akmods images run)
   workflow_dispatch:

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   schedule:
     - cron: '55 2 * * *'  # 2:55am-ish UTC everyday (approx 50 minutes after akmods images run)
   workflow_dispatch:


### PR DESCRIPTION
Small tweak, but we don't need to spend builders for no reason when only markdown changes.