### PR TITLE
fix: correct the filename for ConditionPathExists on ucore-signed-autorebase.service

### DIFF
--- a/examples/ucore-autorebase.butane
+++ b/examples/ucore-autorebase.butane
@@ -36,7 +36,7 @@ systemd:
         [Unit]
         Description=uCore autorebase to signed OCI and reboot
         ConditionPathExists=/etc/ucore-autorebase/unverified
-        ConditionPathExists=!/etc/ucore-autorebase/verified
+        ConditionPathExists=!/etc/ucore-autorebase/signed
         After=network-online.target
         Wants=network-online.target
         [Service]


### PR DESCRIPTION
Minor fix on the example autorebase butane file. I think that 
```
ConditionPathExists=!/etc/ucore-autorebase/verified
```

was intended to be 

```
ConditionPathExists=!/etc/ucore-autorebase/signed
```

Not a big deal since it won't impact the end result as `/etc/ucore-autorebase/verified` does not exist as well. But `/etc/ucore-autorebase/verified` would be "more correct" since that is the file being created on successful run.

I noticed this as I took the example and modified it for my custom ucore image and accidentally introduced a bug in my butane file as a result.