### PR TITLE
Add tuned to ucore image

### DIFF
--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -38,5 +38,8 @@ fi
 # install packages direct from github
 /ctx/github-release-install.sh trapexit/mergerfs "fc${RELEASE}.x86_64"
 
+# disable tuned service by default
+systemctl disable tuned.service
+
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore)"/' /usr/lib/os-release

--- a/ucore/packages.json
+++ b/ucore/packages.json
@@ -41,6 +41,9 @@
                 "samba-usershares",
                 "snapraid",
                 "tiwilink-firmware",
+                "tuned",
+                "tuned-profiles-atomic",
+                "tuned-utils",
                 "usbutils",
                 "xdg-dbus-proxy",
                 "xdg-user-dirs"


### PR DESCRIPTION
See https://github.com/ublue-os/ucore/issues/229 for more details.

I didn't found any `post-install-ucore.sh` file, is it okay to add the disable command into `install-ucore.sh`?

The following additional packages can be found on the Fedora repo:

```bash
 tuned-profiles-cpu-partitioning.noarch: Additional tuned profile(s) optimized for CPU partitioning
 tuned-profiles-mssql.noarch: Additional tuned profile(s) for MS SQL Server
 tuned-profiles-nfv.noarch: Additional tuned profile(s) targeted to Network Function Virtualization (NFV)
 tuned-profiles-nfv-guest.noarch: Additional tuned profile(s) targeted to Network Function Virtualization (NFV) guest
 tuned-profiles-nfv-host.noarch: Additional tuned profile(s) targeted to Network Function Virtualization (NFV) host
 tuned-profiles-nfv-host-bin.x86_64: Binaries that are needed for the NFV host Tuned profile
 tuned-profiles-openshift.noarch: Additional TuneD profile(s) optimized for OpenShift
 tuned-profiles-oracle.noarch: Additional tuned profile(s) targeted to Oracle loads
 tuned-profiles-postgresql.noarch: Additional tuned profile(s) targeted to PostgreSQL server loads
 tuned-profiles-realtime.noarch: Additional tuned profile(s) targeted to realtime
 tuned-profiles-sap.noarch: Additional tuned profile(s) targeted to SAP NetWeaver loads
 tuned-profiles-sap-hana.noarch: Additional tuned profile(s) targeted to SAP HANA loads
 tuned-profiles-spectrumscale.noarch: Additional tuned profile(s) optimized for IBM Spectrum Scale
 tuned-ppd.noarch: PPD compatibility daemon
 tuned-utils-systemtap.noarch: Disk and net statistic monitoring systemtap scripts
```

I do understand overlay package support will be removed at some point, but I think when you really want this, you would better built your own image/`ks`?

Unfortunately I don't have Fedora Silverblue running at the moment to check which are included by them.