### PR TITLE
chore: hack a forced delay on stable F42

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -125,7 +125,7 @@ jobs:
           command: |
             # pull the base image used for FROM in containerfile so
             # we can retry on that unfortunately common failure case
-            podman pull quay.io/fedora/fedora-coreos:${{ inputs.coreos_version }}
+            podman pull quay.io/fedora/fedora-coreos:${{ env.IMAGE_VERSION }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods:${{ env.KERNEL_FLAVOR }}-${{ env.FEDORA_VERSION }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.KERNEL_FLAVOR }}-${{ env.FEDORA_VERSION }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:${{ env.KERNEL_FLAVOR }}-${{ env.FEDORA_VERSION }}
@@ -242,6 +242,7 @@ jobs:
           build-args: |
             COREOS_VERSION=${{ inputs.coreos_version }}
             FEDORA_VERSION=${{ env.FEDORA_VERSION }}
+            IMAGE_VERSION=${{ env.IMAGE_VERSION }}
             IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }}
             KERNEL_FLAVOR=${{ env.KERNEL_FLAVOR }}
             PR_PREFIX=${{ env.PR_PREFIX }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -504,6 +504,7 @@ jobs:
           build-args: |
             COREOS_VERSION=${{ inputs.coreos_version }}
             FEDORA_VERSION=${{ env.FEDORA_VERSION }}
+            IMAGE_VERSION=${{ env.IMAGE_VERSION }}
             IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }}
             KERNEL_FLAVOR=${{ env.KERNEL_FLAVOR }}
             PR_PREFIX=${{ env.PR_PREFIX }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -383,7 +383,7 @@ jobs:
           command: |
             # pull the base image used for FROM in containerfile so
             # we can retry on that unfortunately common failure case
-            podman pull quay.io/fedora/fedora-coreos:${{ inputs.coreos_version }}
+            podman pull quay.io/fedora/fedora-coreos:${{ env.IMAGE_VERSION }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods:${{ env.KERNEL_FLAVOR }}-${{ env.FEDORA_VERSION }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.KERNEL_FLAVOR }}-${{ env.FEDORA_VERSION }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:${{ env.KERNEL_FLAVOR }}-${{ env.FEDORA_VERSION }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -59,6 +59,11 @@ jobs:
                 exit 1
             fi
 
+            if [ "42.20250410.3.1" == "${image}" ]; then
+                echo "WARNING: Overriding known problematic release. Downgrading from 42.20250410.3.1 to 41.20250331.3.0"
+                image="41.20250331.3.0"
+            fi
+
             fedora=$(echo "$image" | cut -f1 -d.)
             if [ -z "$fedora" ] || [ "null" = "$fedora" ]; then
                 echo "fedora version must not be empty or null"

--- a/fedora-coreos/Containerfile
+++ b/fedora-coreos/Containerfile
@@ -1,5 +1,6 @@
 ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 ARG FEDORA_VERSION="${FEDORA_VERSION:-40}"
+ARG IMAGE_VERSION="${IMAGE_VERSION:-stable}"
 ARG IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io/ublue-os}"
 ARG KERNEL_FLAVOR="${KERNEL_FLAVOR:-coreos-stable}"
 
@@ -16,7 +17,7 @@ FROM ${CONFIG} AS config
 FROM scratch AS ctx
 COPY / /
 
-FROM quay.io/fedora/fedora-coreos:${COREOS_VERSION}
+FROM quay.io/fedora/fedora-coreos:${IMAGE_VERSION}
 
 ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 # build with --build-arg NVIDA_TAG="-nvidia" to install nvidia

--- a/ucore/Containerfile
+++ b/ucore/Containerfile
@@ -1,5 +1,6 @@
 ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 ARG FEDORA_VERSION="${FEDORA_VERSION:-40}"
+ARG IMAGE_VERSION="${IMAGE_VERSION:-stable}"
 ARG IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io/ublue-os}"
 ARG KERNEL_FLAVOR="${KERNEL_FLAVOR:-coreos-stable}"
 
@@ -17,7 +18,7 @@ FROM scratch AS ctx
 COPY / /
 
 # ucore-minimal image section
-FROM quay.io/fedora/fedora-coreos:${COREOS_VERSION} AS ucore-minimal
+FROM quay.io/fedora/fedora-coreos:${IMAGE_VERSION} AS ucore-minimal
 
 ARG COREOS_VERSION="${COREOS_VERSION:-stable}"
 # build with --build-arg NVIDA_TAG="-nvidia" to install nvidia


### PR DESCRIPTION
FCOS 42.20250410.3.1contains kernel 6.14.0-63 a rawhide kernel. We want to delay this release and the only good way at this time is to delay the stable update by one cycle.

This forcibly downgrades a build from 42.20250410.3.1 to 41.20250331.3.0 until stable updates to the next release (which should include kernel 6.14.3-200.