### PR TITLE
fix: remove excluded packages and announce Fedora 42 for uCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ Please take a look at the included modifications, and help us improve uCore if t
 
 ## Announcements
 
+### 2025.05.14 - uCore update to Fedora 42
+
+As of today, Fedora CoreOS upstream has updated to kernel 6.14.3 and uCore has unpinned and is building on F42.
+
 ### 2025.04.30 - uCore delaying Fedora 42 update
 
-As of today, Fedora CoreOS upstream has updated to Fedora 42 as a base, however it uses a rawhide kernel 6.14.0 which our
+As of today, Fedora CoreOS upstream has updated to Fedora 42 as a base, however it uses kernel 6.14.0 which our
 team has agreed, we don't want to ship. As of April 30, this means uCore has been in an inbetween state. We have some hacks
 in place to pin our builds to the last F41 kernel/release 6.13.8/41.20250331.3.0. This also means that rebase from F42 of
 Fedora CoreOS to F41 of uCore will fail. So in the meantime, if you are attempting to install, use the following installer:

--- a/ucore/github-release-install.sh
+++ b/ucore/github-release-install.sh
@@ -44,8 +44,8 @@ set ${SET_X:+-x} -eou pipefail
 API_JSON=$(mktemp /tmp/api-XXXXXXXX.json)
 API="https://api.github.com/repos/${ORG_PROJ}/releases/${RELTAG}"
 
-# retry up to 5 times with 5 second delays for any error included HTTP 404 etc
-curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sL "${API}" -o "${API_JSON}"
+# retry up to 15 times using built-in backoff for any error included HTTP 404 etc
+curl --fail --retry 15 --retry-all-errors -sSL "${API}" -o "${API_JSON}"
 RPM_URLS=$(jq \
     -r \
     --arg arch_filter "${ARCH_FILTER}" \

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -65,7 +65,7 @@ fi
 ## CONDITIONAL: install NVIDIA
 if [[ "-nvidia" == "${NVIDIA_TAG}" ]]; then
     # repo for nvidia rpms
-    curl -L https://negativo17.org/repos/fedora-nvidia.repo -o /etc/yum.repos.d/fedora-nvidia.repo
+    curl --fail --retry 15 --retry-all-errors -sSL https://negativo17.org/repos/fedora-nvidia.repo -o /etc/yum.repos.d/fedora-nvidia.repo
 
     dnf -y install /tmp/rpms/akmods-nvidia/ucore/ublue-os-ucore-nvidia*.rpm
     sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/nvidia-container-toolkit.repo
@@ -79,7 +79,7 @@ fi
 ## ALWAYS: install regular packages
 
 # add tailscale repo
-curl -L https://pkgs.tailscale.com/stable/fedora/tailscale.repo -o /etc/yum.repos.d/tailscale.repo
+curl --fail --retry 15 --retry-all-errors -sSL https://pkgs.tailscale.com/stable/fedora/tailscale.repo -o /etc/yum.repos.d/tailscale.repo
 
 # install packages.json stuffs
 export IMAGE_NAME=ucore-minimal

--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -16,10 +16,10 @@ export IMAGE_NAME=ucore
 ## CONDITIONAL: ZFS support
 if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     # cockpit plugin for ZFS management
-    curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL -o /tmp/cockpit-zfs-manager-api.json \
+    curl --fail --retry 15 --retry-all-errors -sSL -o /tmp/cockpit-zfs-manager-api.json \
         "https://api.github.com/repos/45Drives/cockpit-zfs-manager/releases/latest"
     CZM_TGZ_URL=$(jq -r .tarball_url /tmp/cockpit-zfs-manager-api.json)
-    curl -sSL -o /tmp/cockpit-zfs-manager.tar.gz "${CZM_TGZ_URL}"
+    curl --fail --retry 15 --retry-all-errors -sSL -o /tmp/cockpit-zfs-manager.tar.gz "${CZM_TGZ_URL}"
 
     mkdir -p /tmp/cockpit-zfs-manager
     tar -zxvf /tmp/cockpit-zfs-manager.tar.gz -C /tmp/cockpit-zfs-manager --strip-components=1
@@ -27,7 +27,7 @@ if [[ "-zfs" == "${ZFS_TAG}" ]]; then
     mv /tmp/cockpit-zfs-manager/polkit-1/rules.d/* /usr/share/polkit-1/rules.d/
     mv /tmp/cockpit-zfs-manager/zfs /usr/share/cockpit
 
-    curl -sSL -o /tmp/cockpit-zfs-manager-font-fix.sh \
+    curl --fail --retry 15 --retry-all-errors -sSL -o /tmp/cockpit-zfs-manager-font-fix.sh \
         https://raw.githubusercontent.com/45Drives/scripts/refs/heads/main/cockpit_font_fix/fix-cockpit.sh
     chmod +x /tmp/cockpit-zfs-manager-font-fix.sh
     /tmp/cockpit-zfs-manager-font-fix.sh

--- a/ucore/packages.sh
+++ b/ucore/packages.sh
@@ -4,10 +4,23 @@ set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
 
+# build list of all packages requested for exclusion
+EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+                             (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+                             | sort | unique[]" /ctx/packages.json))
+
 # build list of all packages requested for inclusion
 INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
                              | sort | unique[]" /ctx/packages.json))
+
+# remove any excluded packages which are present on image before install
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    dnf -y remove \
+        "${EXCLUDED_PACKAGES[@]}"
+else
+    echo "No packages to remove."
+fi
 
 # Install Packages
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
@@ -17,11 +30,6 @@ else
     echo "No packages to install."
 
 fi
-
-# build list of all packages requested for exclusion
-EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
-                             (select(.\"$COREOS_VERSION\" != null).\"$COREOS_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
-                             | sort | unique[]" /ctx/packages.json))
 
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))


### PR DESCRIPTION
docs: announced Fedora 42 for uCore

also remove incorrect reference to 6.14.0 kernel as "rawhide".

fix: ensure "excluded" packages are removed before installing

In the recent change to dnf from rpm-ostree, the packages.sh script
had a bug introduced which didn't show until F42. Excluded packages need
to be removed before installing packages, in case there is a conflict
between an existing and to be installed package.