### PR TITLE
chore: update docker buildx/compose plugins

### DIFF
--- a/ucore/Containerfile
+++ b/ucore/Containerfile
@@ -24,10 +24,9 @@ ARG NVIDIA_TAG="${NVIDIA_TAG}"
 # build with --build-arg ZFS_TAG="-zfs" to install zfs
 ARG ZFS_TAG="${ZFS_TAG}"
 
-# 0.12.1 matches docker/moby 24.0.5 which FCOS ships as of 40.20240421
-ARG DOCKER_BUILDX_VERSION=0.12.1
-# 2.24.7 matches docker/moby 24.0.5  which FCOS ships as of 40.20240421
-ARG DOCKER_COMPOSE_VERSION=v2.24.7
+# thes versions match docker/moby 27.5.1 which FCOS ships as of 42.20250410
+ARG DOCKER_BUILDX_VERSION=0.20.0
+ARG DOCKER_COMPOSE_VERSION=v2.32.2
 
 COPY system_files/etc /
 COPY system_files/usr/lib /usr/lib/

--- a/ucore/Containerfile
+++ b/ucore/Containerfile
@@ -24,7 +24,7 @@ ARG NVIDIA_TAG="${NVIDIA_TAG}"
 # build with --build-arg ZFS_TAG="-zfs" to install zfs
 ARG ZFS_TAG="${ZFS_TAG}"
 
-# thes versions match docker/moby 27.5.1 which FCOS ships as of 42.20250410
+# these versions match docker/moby 27.5.1 which FCOS ships as of 42.20250410
 ARG DOCKER_BUILDX_VERSION=0.20.0
 ARG DOCKER_COMPOSE_VERSION=v2.32.2
 


### PR DESCRIPTION
It's past time to update buildx and compose plugins.

This brings them in sync with the version of moby-engine which has shipped on Fedora 42 CoreOS since 42.20250410.