### PR TITLE
fix: only remove kernel package if installed

### DIFF
--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -50,7 +50,9 @@ if [[ "${KERNEL_VERSION}" == "${QUALIFIED_KERNEL}" ]]; then
 else
     # Remove Existing Kernel
     for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra; do
-        rpm --erase $pkg --nodeps
+        if rpm -q $pkg >/dev/null 2>&1; then
+            rpm --erase $pkg --nodeps
+        fi
     done
     echo "Install kernel version ${KERNEL_VERSION} from kernel-cache."
     dnf -y install \


### PR DESCRIPTION
Avoids errors when kernel-modules-extra (or other listed packages) is not installed.
This keeps the package in the removal list in case it returns in the future.