### PR TITLE
fix: add smartctl, a missing snapraid dependency

### DIFF
--- a/ucore/packages.json
+++ b/ucore/packages.json
@@ -42,6 +42,7 @@
                 "samba",
                 "samba-usershares",
                 "sanoid",
+                "smartctl",
                 "snapraid",
                 "tiwilink-firmware",
                 "usbutils",


### PR DESCRIPTION
Thanks to @zeitue for noticing this smartraid dependency was missing.

Fixes: #278