### PR TITLE
feat: more secure Cockpit login

### DIFF
--- a/ucore/post-install-ucore-minimal.sh
+++ b/ucore/post-install-ucore-minimal.sh
@@ -27,9 +27,6 @@ systemctl enable rpm-ostreed-automatic.timer
 
 sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf
 
-# workaround to enable cockpit web logins
-rm /etc/ssh/sshd_config.d/40-disable-passwords.conf
-
 # workaround until distrobox patch for this makes it into repos
 ln -s  ../usr/share/zoneinfo/UTC /etc/localtime
 

--- a/ucore/system_files/etc/ssh/sshd_config.d/90-enable-localhost-passwords.conf
+++ b/ucore/system_files/etc/ssh/sshd_config.d/90-enable-localhost-passwords.conf
@@ -1,0 +1,4 @@
+# uCore modification
+# enables Cockpit web login without exposing password auth to network
+Match Address 127.0.0.1,::1
+  PasswordAuthentication yes


### PR DESCRIPTION
Instead of enabling SSH password login on any network, this now restricts password login to localhost (both IPv4 and IPv6).

This is the minimum requirement to enable Cockpit logins.

Closes: #275