### PR TITLE
feat: don't warn about OCI migration

### DIFF
--- a/ucore/post-install-ucore-minimal.sh
+++ b/ucore/post-install-ucore-minimal.sh
@@ -15,6 +15,7 @@ fi
 ## ALWAYS: regular post-install
 ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
 
+systemctl disable coreos-oci-migration-motd.service
 systemctl disable docker.socket
 systemctl disable zincati.service
 


### PR DESCRIPTION
Fedora CoreOS' Zincati now supports OCI and a service was added to encourage users to migrate to OCI.

As uCore is already OCI based, this warning is not applicable to uCore users.

Disable the warning.

Closes: #282