### PR TITLE
fix: pass zfs-import-scan by removing zfs from initramfs

### DIFF
--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -54,19 +54,21 @@ dnf -y install \
 # Ensure kernel packages can't be updated by other dnf operations
 dnf versionlock add kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
 
+# Regenerate initramfs, for new kernel; not including NVIDIA or ZFS kmods
+QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed -E 's/kernel-//')"
+/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
+
 ## ALWAYS: install ZFS (and sanoid deps)
+# uCore does not support ZFS as rootfs, thus does not provide it in the initramfs
 dnf -y install /tmp/rpms/akmods-zfs/kmods/zfs/*.rpm /tmp/rpms/akmods-zfs/kmods/zfs/other/zfs-dracut-*.rpm
 # for some reason depmod ran automatically with zfs 2.1 but not with 2.2
 echo "Update modules.dep, etc..."
 depmod -a "${KERNEL_VERSION}"
 
-# Regenerate initramfs, for new kernel and zfs; not including NVIDIA kmod
-QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(\d+\.\d+\.\d+)' | sed -E 's/kernel-//')"
-/usr/bin/dracut --no-hostonly --kver "$QUALIFIED_KERNEL" --reproducible -v --add ostree -f "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
-chmod 0600 "/lib/modules/$QUALIFIED_KERNEL/initramfs.img"
-
 ## CONDITIONAL: install NVIDIA
 if [[ "-nvidia" == "${NVIDIA_TAG}" ]]; then
+    # uCore expects NVIDIA drivers are able to hot load/unload, thus does not provide it in the initramfs
     # repo for nvidia rpms
     curl --fail --retry 15 --retry-all-errors -sSL https://negativo17.org/repos/fedora-nvidia.repo -o /etc/yum.repos.d/fedora-nvidia.repo
 


### PR DESCRIPTION
306b356440c222e62a9bd24957f9bc3593fb27f3 ensured initramfs always regenerates at uCore build time. However, it also included ZFS, which was a significant, and unnecessary change.

Having it included causes ZFS to attempt to import zpools before the hostname has been set, thus resuling in an error like:

````
root@testhost:~# journalctl -u zfs-import-scan
Nov 11 09:57:25 localhost systemd[1]: Starting zfs-import-scan.service - Import ZFS pools by device scanning...
Nov 11 09:57:26 localhost zpool[1092]: cannot import 'zdata': pool was previously in use from another system.
Nov 11 09:57:26 localhost zpool[1092]: Last accessed by testhost(hostid=0) at Tue Nov 11 15:31:17 2025
Nov 11 09:57:26 localhost zpool[1092]: The pool can be imported, use 'zpool import -f' to import the pool.
Nov 11 09:57:26 localhost systemd[1]: zfs-import-scan.service: Main process exited, code=exited, status=1/FAILURE
Nov 11 09:57:26 localhost systemd[1]: zfs-import-scan.service: Failed with result 'exit-code'.
Nov 11 09:57:26 localhost systemd[1]: Failed to start zfs-import-scan.service - Import ZFS pools by device scanning.
````

uCore does not support ZFS as root filesystem, so it is not required in the initramfs.