### PR TITLE
feat: add tuned to ucore-minimal (and ucore and hci) images

### DIFF
--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -111,6 +111,11 @@ fi
 
 ## ALWAYS: install regular packages
 
+# install tuned without weak deps (kernel-tools and python3-perf)
+dnf -y install --setopt=install_weak_deps=False \
+    tuned \
+    tuned-profiles-atomic
+
 # add tailscale repo
 curl --fail --retry 15 --retry-all-errors -sSL https://pkgs.tailscale.com/stable/fedora/tailscale.repo -o /etc/yum.repos.d/tailscale.repo
 

--- a/ucore/post-install-ucore-minimal.sh
+++ b/ucore/post-install-ucore-minimal.sh
@@ -6,6 +6,7 @@ set -ouex pipefail
 systemctl mask coreos-container-signing-migration-motd.service
 systemctl mask coreos-oci-migration-motd.service
 systemctl disable docker.socket
+systemctl disable tuned.service
 systemctl disable zincati.service
 
 systemctl enable gssproxy-workaround.service


### PR DESCRIPTION
This adds tuned with atomic profile but does not include the heavier weak deps of kernel-tools and python3-perf. tuned.service is disabled by default.

Though previous discussions did mention not installing this to the minimal image, since the atomic profile specifically provides a profile for VM guests, it seems reasonable there as well.


Closes: #229 
Closes: #291 