### PR TITLE
docs: remove a reference to the no longer published zfs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ This image builds on `ucore-minimal` but adds drivers, storage tools and utiliti
   - [samba](https://www.samba.org/) and samba-usershares to provide SMB sevices
   - [snapraid](https://www.snapraid.it/)
   - usbutils(and pciutils) - technically pciutils is pulled in by open-vm-tools in ucore-minimal
-- Optional [ZFS versions](#tag-matrix) add:
   - [cockpit-zfs-manager](https://github.com/45Drives/cockpit-zfs-manager) (an interactive ZFS on Linux admin package for Cockpit)
   - [sanoid/syncoid dependencies](https://github.com/jimsalterjrs/sanoid) - [see below](#zfs) for details
 


### PR DESCRIPTION
A small correction to the documentation since [the ZFS images publication has been stopped earlier this month](https://github.com/ublue-os/ucore?tab=readme-ov-file#20251210---nvidia-580-lts-and-nvidia-590-open).
