### PR TITLE
Add lm_sensors to installation script

### DIFF
--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -18,6 +18,7 @@ dnf -y install \
     iwlegacy-firmware \
     iwlwifi-dvm-firmware \
     iwlwifi-mvm-firmware \
+    lm_sensors \
     man-db \
     mt7xxx-firmware \
     nxpwireless-firmware \


### PR DESCRIPTION
Solves https://github.com/ublue-os/ucore/issues/345

It will be enabled by default, because it seems ucore main purpose is to be used on metal. If you want, I add a service disable for the minimal variant.