### PR TITLE
fix: disable ublue COPR repos before generic package installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 Containerfile
+ucore/audit

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -69,3 +69,49 @@ build upstream_image='':
     podman build -f Containerfile \
         --target {{ TARGET_IMAGE }} \
         -t "{{ TARGET_IMAGE }}:${BUILD_TAG}" .
+
+package-provenance image='' output='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    IMAGE='{{ image }}'
+    BUILD_TAG='{{ CI_BUILD_TAG }}'
+    if [ -z "$IMAGE" ]; then
+        if [ -z "$BUILD_TAG" ]; then
+            BUILD_TAG='{{ UCORE_STREAM }}{{ NVIDIA_TAG }}'
+        fi
+        IMAGE='{{ TARGET_IMAGE }}:'"$BUILD_TAG"
+    fi
+
+    OUTPUT='{{ output }}'
+    if [ -z "$OUTPUT" ]; then
+        NVIDIA_SEGMENT='{{ NVIDIA_TAG }}'
+        if [ -n "$NVIDIA_SEGMENT" ]; then
+            NVIDIA_SEGMENT="-${NVIDIA_SEGMENT#-}"
+        fi
+        OUTPUT="audit/{{ TARGET_IMAGE }}-{{ UCORE_STREAM }}${NVIDIA_SEGMENT}-package-provenance.txt"
+    fi
+
+    if ! podman image exists "$IMAGE"; then
+        printf 'Local image not found: %s\n' "$IMAGE" >&2
+        printf 'Build it first with the matching environment, for example:\n' >&2
+        printf '  TARGET_IMAGE=%s UCORE_STREAM=%s NVIDIA_TAG=%s just build\n' \
+            '{{ TARGET_IMAGE }}' '{{ UCORE_STREAM }}' '{{ NVIDIA_TAG }}' >&2
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$OUTPUT")"
+    podman run --rm --entrypoint /usr/bin/bash "$IMAGE" -lc \
+        "dnf repoquery --installed --qf '%{name}|%{evr}|%{arch}|%{from_repo}\n' | sort" \
+        > "$OUTPUT"
+
+    printf 'Wrote package provenance to %s\n' "$OUTPUT"
+    printf 'Repo counts:\n'
+    cut -d '|' -f4 "$OUTPUT" | sort | uniq -c | sort -nr
+
+    if grep -Fq 'copr:' "$OUTPUT"; then
+        printf '\nCOPR-installed packages:\n'
+        grep -F 'copr:' "$OUTPUT"
+    else
+        printf '\nNo installed packages are currently attributed to COPR repos.\n'
+    fi

--- a/ucore/install-ucore-hci.sh
+++ b/ucore/install-ucore-hci.sh
@@ -3,11 +3,11 @@
 set -ouex pipefail
 
 # install packages
+dnf -y --enable-repo='copr:copr.fedorainfracloud.org:ublue-os:packages' install ublue-os-libvirt-workarounds
 dnf -y install \
     cockpit-machines \
     libvirt-client \
     libvirt-daemon-kvm \
-    ublue-os-libvirt-workarounds \
     virt-install
 
 # tweak os-release

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -29,10 +29,10 @@ for REPO in $(ls /etc/yum.repos.d/fedora-updates-testing.repo); do
 done
 fi
 
-# enable ublue-os repos
+# keep ublue-os COPR repos scoped to the packages that explicitly need them
 dnf -y install dnf5-plugins
-dnf -y copr enable ublue-os/packages
-dnf -y copr enable ublue-os/staging
+dnf -y copr enable ublue-os/packages && dnf -y copr disable ublue-os/packages
+dnf -y copr enable ublue-os/staging && dnf -y copr disable ublue-os/staging
 
 # always disable cisco-open264 repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
@@ -44,7 +44,7 @@ find /tmp/rpms/
 # provide ublue-akmods public_key for MOK enroll
 dnf -y install /tmp/rpms/akmods-zfs/ucore/ublue-os-ucore-addons*.rpm
 
-dnf -y install ublue-os-signing
+dnf -y --enable-repo='copr:copr.fedorainfracloud.org:ublue-os:packages' install ublue-os-signing
 
 # Put the policy file in the correct place and cleanup /usr/etc
 cp /usr/etc/containers/policy.json /etc/containers/policy.json

--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -27,13 +27,15 @@ dnf -y install \
     realtek-firmware \
     samba \
     samba-usershares \
-    sanoid \
     smartctl \
     snapraid \
     tiwilink-firmware \
     usbutils \
     xdg-dbus-proxy \
     xdg-user-dirs
+
+# sanoid currently comes from ublue-os staging COPR
+dnf -y --enable-repo='copr:copr.fedorainfracloud.org:ublue-os:staging' install sanoid
 
 # install packages direct from github
 if [[ "${RELEASE}" -ge "43" ]]; then


### PR DESCRIPTION
Disable the ublue COPR repos by default. Only use COPR repos with explicit permission so installs clearly resolve from Fedor and intended repos instead.

This reduces the chance for unintended package drift from COPR without changing the existing packages that still require it.

Add an env-driven package provenance audit recipe that mirrors just build tag selection and writes per-variant audit reports for local validation.

Closes: #363 