### PR TITLE
fix(ci): vendor tailscale repo and improve provenance output

### DIFF
--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -146,9 +146,9 @@ package-provenance image='' output='':
     printf 'Repo counts:\n'
     cut -d '|' -f4 "$OUTPUT" | sort | uniq -c | sort -nr
 
-    if grep -Fq 'copr:' "$OUTPUT"; then
-        printf '\nCOPR-installed packages:\n'
-        grep -F 'copr:' "$OUTPUT"
-    else
-        printf '\nNo installed packages are currently attributed to COPR repos.\n'
-    fi
+    printf '\nNon-Fedora packages...\n'
+    for NON_FED_REPO in $(cat "$OUTPUT" | rev | cut -f1 -d\| | rev |sort -u | grep -v -E "^fedora$|^updates$|^updates-archive$|^<unknown>$");
+    do
+        printf "\n$NON_FED_REPO packages:\n"
+        grep "$NON_FED_REPO$" "$OUTPUT"
+    done

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -102,9 +102,7 @@ if [[ "x86_64" == "${ARCH}" ]]; then
 fi
 
 ## ALWAYS: install regular packages
-
-# add tailscale repo
-curl --fail --retry 15 --retry-all-errors -sSL https://pkgs.tailscale.com/stable/fedora/tailscale.repo -o /etc/yum.repos.d/tailscale.repo
+dnf -y --enable-repo=tailscale-stable install tailscale
 
 # install packages
 dnf -y install \
@@ -123,7 +121,6 @@ dnf -y install \
     podman-compose \
     pv \
     qemu-guest-agent \
-    tailscale \
     tmux \
     wireguard-tools
 

--- a/ucore/system_files/etc/yum.repos.d/tailscale.repo
+++ b/ucore/system_files/etc/yum.repos.d/tailscale.repo
@@ -1,0 +1,8 @@
+[tailscale-stable]
+name=Tailscale stable
+baseurl=https://pkgs.tailscale.com/stable/fedora/$basearch
+enabled=0
+type=rpm
+repo_gpgcheck=1
+gpgcheck=1
+gpgkey=https://pkgs.tailscale.com/stable/fedora/repo.gpg


### PR DESCRIPTION
tailscale.repo is now included as a known build input rather than downloaded at runtime.

Provenance output shows all non-Fedora provided packages.