### PR TITLE
feat: generate SBOMs and attach to image builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -573,6 +573,10 @@ jobs:
           DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
         run: |
           set -xeuo pipefail
+          if [[ -z "${DIGEST}" || "${DIGEST}" == "false" ]]; then
+            echo "::error::Manifest digest is missing or invalid"
+            exit 1
+          fi
           for SBOM_FILE in $(find images -type f -name "sbom.json"); do
             cd "$(dirname "${SBOM_FILE}")"
             oras attach \
@@ -581,18 +585,27 @@ jobs:
               sbom.json
             cd -
           done
-          sbom_digest=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[] | select(.artifactType == "application/vnd.syft+json") | .digest' | head -n1)
-          echo "sbom_digest=${sbom_digest}" >> $GITHUB_OUTPUT
+          sbom_digests=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[]? | select(.artifactType == "application/vnd.syft+json") | .digest')
+          if [[ -z "${sbom_digests}" ]]; then
+            echo "::error::No SBOM artifacts discovered for ${IMAGE}@${DIGEST}"
+            exit 1
+          fi
+          echo "sbom_digests<<EOF" >> $GITHUB_OUTPUT
+          echo "${sbom_digests}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Sign SBOM OCI Artifact
+      - name: Sign SBOM OCI Artifacts
         if: github.event_name != 'pull_request'
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}"
+          set -xeuo pipefail
+          while IFS= read -r sbom_digest; do
+            echo "Signing SBOM artifact: ${IMAGE}@${sbom_digest}"
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${sbom_digest}"
+          done <<< "${{ steps.upload-sbom.outputs.sbom_digests }}"
 
   check:
     name: Check all successful

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -280,16 +280,17 @@ jobs:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
           OCI_DIR: "/tmp/image-oci-dir"
         run: |
+          SBOM_DIR="$(mktemp -d)"
+          SBOM="${SBOM_DIR}/sbom.json"
+          trap 'rm -rf "${OCI_DIR}" "${SBOM_DIR}"' EXIT
           mkdir -p ${OCI_DIR}/rootfs
-          sudo podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
-          sudo podman export "${IMAGE}" | sudo tar -C ${OCI_DIR}/rootfs -xf -
-          sudo podman container rm "${IMAGE}"
-          SBOM="$(mktemp -d)/sbom.json"
+          podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
+          podman export "${IMAGE}" | tar --no-same-owner -C ${OCI_DIR}/rootfs -xf -
+          podman container rm "${IMAGE}"
           export SYFT_PARALLELISM=$(($(nproc)*2))
-          sudo $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
+          $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
           du -sh ${SBOM}
           cp ${SBOM} sbom.json
-          sudo rm -rf ${OCI_DIR}
 
       - name: Package Provenance
         run: |
@@ -577,14 +578,15 @@ jobs:
             echo "::error::Manifest digest is missing or invalid"
             exit 1
           fi
-          for SBOM_FILE in $(find images -type f -name "sbom.json"); do
+          CURRENT_DIR="$(pwd)"
+          while IFS= read -r -d '' SBOM_FILE; do
             cd "$(dirname "${SBOM_FILE}")"
             oras attach \
               --artifact-type application/vnd.syft+json \
               "${IMAGE}@${DIGEST}" \
               sbom.json
-            cd -
-          done
+            cd "${CURRENT_DIR}"
+          done < <(find images -type f -name "sbom.json" -print0)
           sbom_digests=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[]? | select(.artifactType == "application/vnd.syft+json") | .digest')
           if [[ -z "${sbom_digests}" ]]; then
             echo "::error::No SBOM artifacts discovered for ${IMAGE}@${DIGEST}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -264,6 +264,33 @@ jobs:
           extra-args: |
             --target=${{ env.IMAGE_NAME }}
 
+      - name: Setup Syft
+        id: setup-syft
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          syft-version: v1.39.0
+
+      - name: Generate SBOM
+        if: github.event_name != 'pull_request'
+        id: generate-sbom
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          TAG: ${{ env.TAG_VERSION_ARCH }}
+          SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
+          OCI_DIR: "/tmp/image-oci-dir"
+        run: |
+          mkdir -p ${OCI_DIR}/rootfs
+          sudo podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
+          sudo podman export "${IMAGE}" | sudo tar -C ${OCI_DIR}/rootfs -xf -
+          sudo podman container rm "${IMAGE}"
+          SBOM="$(mktemp -d)/sbom.json"
+          export SYFT_PARALLELISM=$(($(nproc)*2))
+          sudo $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
+          du -sh ${SBOM}
+          cp ${SBOM} sbom.json
+          sudo rm -rf ${OCI_DIR}
+
       - name: Package Provenance
         run: |
           pushd ucore
@@ -328,6 +355,7 @@ jobs:
             image.env
             labels.txt
             package-provenance.txt
+            sbom.json
           retention-days: 7
 
   check_builds:
@@ -527,6 +555,44 @@ jobs:
         run: |
           echo "Signing ${{ env.REGISTRY_PATH }}@${{ env.DIGEST }}"
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_PATH }}@${{ env.DIGEST }}
+
+      - name: Install ORAS
+        if: github.event_name != 'pull_request'
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Login to GitHub Container Registry with ORAS
+        if: github.event_name != 'pull_request'
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Upload SBOMs
+        if: github.event_name != 'pull_request'
+        id: upload-sbom
+        env:
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
+        run: |
+          set -xeuo pipefail
+          for SBOM_FILE in $(find images -type f -name "sbom.json"); do
+            cd "$(dirname "${SBOM_FILE}")"
+            oras attach \
+              --artifact-type application/vnd.syft+json \
+              "${IMAGE}@${DIGEST}" \
+              sbom.json
+            cd -
+          done
+          sbom_digest=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[] | select(.artifactType == "application/vnd.syft+json") | .digest' | head -n1)
+          echo "sbom_digest=${sbom_digest}" >> $GITHUB_OUTPUT
+
+      - name: Sign SBOM OCI Artifact
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}"
 
   check:
     name: Check all successful

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -282,16 +282,17 @@ jobs:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
           OCI_DIR: "/tmp/image-oci-dir"
         run: |
+          SBOM_DIR="$(mktemp -d)"
+          SBOM="${SBOM_DIR}/sbom.json"
+          trap 'rm -rf "${OCI_DIR}" "${SBOM_DIR}"' EXIT
           mkdir -p ${OCI_DIR}/rootfs
-          sudo podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
-          sudo podman export "${IMAGE}" | sudo tar -C ${OCI_DIR}/rootfs -xf -
-          sudo podman container rm "${IMAGE}"
-          SBOM="$(mktemp -d)/sbom.json"
+          podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
+          podman export "${IMAGE}" | tar --no-same-owner -C ${OCI_DIR}/rootfs -xf -
+          podman container rm "${IMAGE}"
           export SYFT_PARALLELISM=$(($(nproc)*2))
-          sudo $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
+          $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
           du -sh ${SBOM}
           cp ${SBOM} sbom.json
-          sudo rm -rf ${OCI_DIR}
 
       - name: Package Provenance
         run: |
@@ -594,14 +595,15 @@ jobs:
             echo "::error::Manifest digest is missing or invalid"
             exit 1
           fi
-          for SBOM_FILE in $(find images -type f -name "sbom.json"); do
+          CURRENT_DIR="$(pwd)"
+          while IFS= read -r -d '' SBOM_FILE; do
             cd "$(dirname "${SBOM_FILE}")"
             oras attach \
               --artifact-type application/vnd.syft+json \
               "${IMAGE}@${DIGEST}" \
               sbom.json
-            cd -
-          done
+            cd "${CURRENT_DIR}"
+          done < <(find images -type f -name "sbom.json" -print0)
           sbom_digests=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[]? | select(.artifactType == "application/vnd.syft+json") | .digest')
           if [[ -z "${sbom_digests}" ]]; then
             echo "::error::No SBOM artifacts discovered for ${IMAGE}@${DIGEST}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -277,22 +277,12 @@ jobs:
         if: github.event_name != 'pull_request'
         id: generate-sbom
         env:
-          IMAGE: ${{ env.IMAGE_NAME }}
-          TAG: ${{ env.TAG_VERSION_ARCH }}
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
-          OCI_DIR: "/tmp/image-oci-dir"
         run: |
-          SBOM_DIR="$(mktemp -d)"
-          SBOM="${SBOM_DIR}/sbom.json"
-          trap 'rm -rf "${OCI_DIR}" "${SBOM_DIR}"' EXIT
-          mkdir -p ${OCI_DIR}/rootfs
-          podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
-          podman export "${IMAGE}" | tar --no-same-owner -C ${OCI_DIR}/rootfs -xf -
-          podman container rm "${IMAGE}"
-          export SYFT_PARALLELISM=$(($(nproc)*2))
-          $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
-          du -sh ${SBOM}
-          cp ${SBOM} sbom.json
+          pushd ucore
+          just gen-sbom \
+              "${{ env.IMAGE_NAME }}:${TAG_VERSION_ARCH}" \
+              ../sbom.json
 
       - name: Package Provenance
         run: |
@@ -581,50 +571,58 @@ jobs:
       - name: Login to GitHub Container Registry with ORAS
         if: github.event_name != 'pull_request'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+          printf '%s' "${{ github.token }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Upload SBOMs
         if: github.event_name != 'pull_request'
         id: upload-sbom
-        env:
-          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
         run: |
           set -xeuo pipefail
-          if [[ -z "${DIGEST}" || "${DIGEST}" == "false" ]]; then
-            echo "::error::Manifest digest is missing or invalid"
-            exit 1
-          fi
-          CURRENT_DIR="$(pwd)"
+          SBOM_REFS=()
           while IFS= read -r -d '' SBOM_FILE; do
-            cd "$(dirname "${SBOM_FILE}")"
-            oras attach \
-              --artifact-type application/vnd.syft+json \
-              "${IMAGE}@${DIGEST}" \
-              sbom.json
-            cd "${CURRENT_DIR}"
+            SBOM_DIR="$(dirname "${SBOM_FILE}")"
+            # shellcheck disable=SC1091
+            source "${SBOM_DIR}/image.env"
+            if [[ -z "${IMAGE_REF:-}" || -z "${IMAGE_DIGEST:-}" ]]; then
+              echo "::error::Missing IMAGE_REF or IMAGE_DIGEST in ${SBOM_DIR}/image.env"
+              exit 1
+            fi
+
+            sbom_ref="$(oras attach \
+              --artifact-type application/vnd.spdx+json \
+              --annotation filename=sbom.json \
+              "${IMAGE_REF}@${IMAGE_DIGEST}" \
+              "${SBOM_FILE}" \
+              --format go-template \
+              --template '{{ .reference }}')"
+
+            if [[ -z "${sbom_ref}" ]]; then
+              echo "::error::ORAS did not return an SBOM artifact reference for ${IMAGE_REF}@${IMAGE_DIGEST}"
+              exit 1
+            fi
+            SBOM_REFS+=("${sbom_ref}")
           done < <(find images -type f -name "sbom.json" -print0)
-          sbom_digests=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[]? | select(.artifactType == "application/vnd.syft+json") | .digest')
-          if [[ -z "${sbom_digests}" ]]; then
-            echo "::error::No SBOM artifacts discovered for ${IMAGE}@${DIGEST}"
+
+          if [[ "${#SBOM_REFS[@]}" -eq 0 ]]; then
+            echo "::error::No SBOM files found under images/"
             exit 1
           fi
-          echo "sbom_digests<<EOF" >> $GITHUB_OUTPUT
-          echo "${sbom_digests}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "sbom_refs<<EOF" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "${SBOM_REFS[@]}" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Sign SBOM OCI Artifacts
         if: github.event_name != 'pull_request'
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
           set -xeuo pipefail
-          while IFS= read -r sbom_digest; do
-            echo "Signing SBOM artifact: ${IMAGE}@${sbom_digest}"
-            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${sbom_digest}"
-          done <<< "${{ steps.upload-sbom.outputs.sbom_digests }}"
+          while IFS= read -r sbom_ref; do
+            echo "Signing SBOM artifact: ${sbom_ref}"
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${sbom_ref}"
+          done <<< "${{ steps.upload-sbom.outputs.sbom_refs }}"
 
   check:
     name: Check all successful

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -266,6 +266,33 @@ jobs:
           extra-args: |
             --target=${{ env.IMAGE_NAME }}
 
+      - name: Setup Syft
+        id: setup-syft
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          syft-version: v1.39.0
+
+      - name: Generate SBOM
+        if: github.event_name != 'pull_request'
+        id: generate-sbom
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          TAG: ${{ env.TAG_VERSION_ARCH }}
+          SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
+          OCI_DIR: "/tmp/image-oci-dir"
+        run: |
+          mkdir -p ${OCI_DIR}/rootfs
+          sudo podman container create --replace --name "${IMAGE}" "localhost/${IMAGE}:${TAG}"
+          sudo podman export "${IMAGE}" | sudo tar -C ${OCI_DIR}/rootfs -xf -
+          sudo podman container rm "${IMAGE}"
+          SBOM="$(mktemp -d)/sbom.json"
+          export SYFT_PARALLELISM=$(($(nproc)*2))
+          sudo $SYFT_CMD --source-name "${IMAGE}-${{ env.TAG_VERSION }}" ${OCI_DIR} -o syft-json=${SBOM}
+          du -sh ${SBOM}
+          cp ${SBOM} sbom.json
+          sudo rm -rf ${OCI_DIR}
+
       - name: Package Provenance
         run: |
           pushd ucore
@@ -337,6 +364,7 @@ jobs:
             image.env
             labels.txt
             package-provenance.txt
+            sbom.json
           retention-days: 7
 
   check_builds:
@@ -544,6 +572,44 @@ jobs:
         run: |
           echo "Signing ${{ env.REGISTRY_PATH }}@${{ env.DIGEST }}"
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_PATH }}@${{ env.DIGEST }}
+
+      - name: Install ORAS
+        if: github.event_name != 'pull_request'
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Login to GitHub Container Registry with ORAS
+        if: github.event_name != 'pull_request'
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Upload SBOMs
+        if: github.event_name != 'pull_request'
+        id: upload-sbom
+        env:
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
+        run: |
+          set -xeuo pipefail
+          for SBOM_FILE in $(find images -type f -name "sbom.json"); do
+            cd "$(dirname "${SBOM_FILE}")"
+            oras attach \
+              --artifact-type application/vnd.syft+json \
+              "${IMAGE}@${DIGEST}" \
+              sbom.json
+            cd -
+          done
+          sbom_digest=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[] | select(.artifactType == "application/vnd.syft+json") | .digest' | head -n1)
+          echo "sbom_digest=${sbom_digest}" >> $GITHUB_OUTPUT
+
+      - name: Sign SBOM OCI Artifact
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}"
 
   check:
     name: Check all successful

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -590,6 +590,10 @@ jobs:
           DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
         run: |
           set -xeuo pipefail
+          if [[ -z "${DIGEST}" || "${DIGEST}" == "false" ]]; then
+            echo "::error::Manifest digest is missing or invalid"
+            exit 1
+          fi
           for SBOM_FILE in $(find images -type f -name "sbom.json"); do
             cd "$(dirname "${SBOM_FILE}")"
             oras attach \
@@ -598,18 +602,27 @@ jobs:
               sbom.json
             cd -
           done
-          sbom_digest=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[] | select(.artifactType == "application/vnd.syft+json") | .digest' | head -n1)
-          echo "sbom_digest=${sbom_digest}" >> $GITHUB_OUTPUT
+          sbom_digests=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[]? | select(.artifactType == "application/vnd.syft+json") | .digest')
+          if [[ -z "${sbom_digests}" ]]; then
+            echo "::error::No SBOM artifacts discovered for ${IMAGE}@${DIGEST}"
+            exit 1
+          fi
+          echo "sbom_digests<<EOF" >> $GITHUB_OUTPUT
+          echo "${sbom_digests}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Sign SBOM OCI Artifact
+      - name: Sign SBOM OCI Artifacts
         if: github.event_name != 'pull_request'
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${SBOM_DIGEST}"
+          set -xeuo pipefail
+          while IFS= read -r sbom_digest; do
+            echo "Signing SBOM artifact: ${IMAGE}@${sbom_digest}"
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${sbom_digest}"
+          done <<< "${{ steps.upload-sbom.outputs.sbom_digests }}"
 
   check:
     name: Check all successful

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Please take a look at the included modifications, and help us improve uCore if t
     - [`ucore`](#ucore)
     - [`ucore-hci`](#ucore-hci)
   - [Tag Matrix](#tag-matrix)
-- [Installation](#installation)
   - [Image Verification](#image-verification)
   - [Software Bill of Materials](#software-bill-of-materials)
+- [Installation](#installation)
   - [Auto-Rebase Install](#auto-rebase-install)
   - [Manual Install/Rebase](#manual-installrebase)
 - [Tips and Tricks](#tips-and-tricks)
@@ -272,18 +272,6 @@ Hyper-Coverged Infrastructure(HCI) refers to storage and hypervisor in one place
 | [`ucore-hci`](#ucore-hci) - *stable* | `stable`, `stable-nvidia`, `stable-nvidia-lts` |
 | [`ucore-hci`](#ucore-hci) - *testing* | `testing`, `testing-nvidia`, `testing-nvidia-lts` |
 
-## Installation
-
-> [!IMPORTANT]
-> **Read the [CoreOS installation guide](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/)** before attempting installation. uCore extends Fedora CoreOS; **it does not provide its own custom or GUI installer**.
-
-There are varying methods of installation for bare metal, cloud providers, and virtualization platforms.
-
-**All CoreOS installation methods require the user to [produce an Ignition file](https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/).** This Ignition file should, at mimimum, set a password and SSH key for the default user (default username is `core`).
-
-> [!TIP]
-> For bare metal installs, first test your ignition configuration by installing in a VM (or other test hardware) using the bare metal process.
-
 ### Image Verification
 
 These images are signed with sigstore's [cosign](https://docs.sigstore.dev/cosign/signing/overview/). You can verify an image tag with the public key:
@@ -345,6 +333,18 @@ oras discover \
   --artifact-type application/vnd.spdx+json \
   "ghcr.io/ublue-os/ucore@${IMAGE_DIGEST}"
 ```
+
+## Installation
+
+> [!IMPORTANT]
+> **Read the [CoreOS installation guide](https://docs.fedoraproject.org/en-US/fedora-coreos/bare-metal/)** before attempting installation. uCore extends Fedora CoreOS; **it does not provide its own custom or GUI installer**.
+
+There are varying methods of installation for bare metal, cloud providers, and virtualization platforms.
+
+**All CoreOS installation methods require the user to [produce an Ignition file](https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/).** This Ignition file should, at mimimum, set a password and SSH key for the default user (default username is `core`).
+
+> [!TIP]
+> For bare metal installs, first test your ignition configuration by installing in a VM (or other test hardware) using the bare metal process.
 
 ### Auto-Rebase Install
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please take a look at the included modifications, and help us improve uCore if t
   - [Tag Matrix](#tag-matrix)
 - [Installation](#installation)
   - [Image Verification](#image-verification)
+  - [Software Bill of Materials](#software-bill-of-materials)
   - [Auto-Rebase Install](#auto-rebase-install)
   - [Manual Install/Rebase](#manual-installrebase)
 - [Tips and Tricks](#tips-and-tricks)
@@ -285,10 +286,64 @@ There are varying methods of installation for bare metal, cloud providers, and v
 
 ### Image Verification
 
-These images are signed with sigstore's [cosign](https://docs.sigstore.dev/cosign/signing/overview/). You can verify the signature by running the following command:
+These images are signed with sigstore's [cosign](https://docs.sigstore.dev/cosign/signing/overview/). You can verify an image tag with the public key:
 
 ```bash
 cosign verify --key https://github.com/ublue-os/ucore/raw/main/cosign.pub ghcr.io/ublue-os/IMAGE:TAG
+```
+
+For an exact architecture-specific image, verify the resolved digest instead:
+
+```bash
+cosign verify --key https://github.com/ublue-os/ucore/raw/main/cosign.pub ghcr.io/ublue-os/IMAGE@sha256:IMAGE_DIGEST
+```
+
+For example:
+
+```bash
+cosign verify --key https://github.com/ublue-os/ucore/raw/main/cosign.pub ghcr.io/ublue-os/ucore:stable
+```
+
+### Software Bill of Materials
+
+uCore publishes SPDX JSON SBOMs for each architecture-specific image digest. Multi-arch tags such as `stable` resolve to a platform-specific image, and the SBOM is attached to that resolved image digest rather than only to the multi-arch manifest.
+
+To inspect the SBOM for an image, first resolve the digest for the platform you want to audit:
+
+```bash
+skopeo inspect --raw docker://ghcr.io/ublue-os/IMAGE:TAG \
+  | jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest'
+```
+
+Then discover the SPDX SBOM attached to the platform image digest:
+
+```bash
+oras discover \
+  --artifact-type application/vnd.spdx+json \
+  ghcr.io/ublue-os/IMAGE@sha256:IMAGE_DIGEST
+```
+
+You can pull the SBOM artifact by digest:
+
+```bash
+oras pull ghcr.io/ublue-os/IMAGE@sha256:SBOM_ARTIFACT_DIGEST
+```
+
+SBOM artifacts are signed with cosign and can be verified with the same public key:
+
+```bash
+cosign verify --key https://github.com/ublue-os/ucore/raw/main/cosign.pub ghcr.io/ublue-os/IMAGE@sha256:SBOM_ARTIFACT_DIGEST
+```
+
+For example, to inspect the `amd64` SBOM for `ucore:stable`, resolve the image digest and discover the SBOM artifact:
+
+```bash
+IMAGE_DIGEST="$(skopeo inspect --raw docker://ghcr.io/ublue-os/ucore:stable \
+  | jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest')"
+
+oras discover \
+  --artifact-type application/vnd.spdx+json \
+  "ghcr.io/ublue-os/ucore@${IMAGE_DIGEST}"
 ```
 
 ### Auto-Rebase Install

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -199,5 +199,5 @@ gen-sbom image='' output='':
     podman export "$CONTAINER" | tar --no-same-owner -C "$ROOTFS" -xf -
 
     export SYFT_PARALLELISM="${SYFT_PARALLELISM:-$(($(nproc) * 2))}"
-    "{{ SYFT_CMD }}" --source-name "$IMAGE" "$WORK_DIR" -o "spdx-json=$OUTPUT"
+    "{{ SYFT_CMD }}" --source-name "$IMAGE" "$ROOTFS" -o "spdx-json=$OUTPUT"
     du -sh "$OUTPUT"

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -10,6 +10,7 @@ KERNEL_FLAVOR := env("KERNEL_FLAVOR", if UCORE_STREAM == 'lts' { "longterm-6.18"
 KERNEL_VERSION := env("KERNEL_VERSION", "")
 NVIDIA_TAG := env("NVIDIA_TAG", "")
 SELINUX := path_exists('/sys/fs/selinux')
+SYFT_CMD := env("SYFT_CMD", "syft")
 TARGET_IMAGE := env("TARGET_IMAGE", "ucore-minimal")
 
 _default:
@@ -153,3 +154,50 @@ package-provenance image='' output='':
         printf "\n$NON_FED_REPO packages:\n"
         grep "$NON_FED_REPO$" "$OUTPUT"
     done
+
+gen-sbom image='' output='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    IMAGE='{{ image }}'
+    BUILD_TAG='{{ CI_BUILD_TAG }}'
+    if [ -z "$IMAGE" ]; then
+        if [ -z "$BUILD_TAG" ]; then
+            BUILD_TAG='{{ UCORE_STREAM }}{{ NVIDIA_TAG }}'
+        fi
+        IMAGE='{{ TARGET_IMAGE }}:'"$BUILD_TAG"
+    fi
+
+    OUTPUT='{{ output }}'
+    if [ -z "$OUTPUT" ]; then
+        NVIDIA_SEGMENT='{{ NVIDIA_TAG }}'
+        if [ -n "$NVIDIA_SEGMENT" ]; then
+            NVIDIA_SEGMENT="-${NVIDIA_SEGMENT#-}"
+        fi
+        OUTPUT="audit/{{ TARGET_IMAGE }}-{{ UCORE_STREAM }}${NVIDIA_SEGMENT}-sbom.spdx.json"
+    fi
+
+    if ! podman image exists "$IMAGE"; then
+        if podman image exists "localhost/$IMAGE"; then
+            IMAGE="localhost/$IMAGE"
+        else
+            printf 'Local image not found: %s\n' "$IMAGE" >&2
+            printf 'Build it first with the matching environment, for example:\n' >&2
+            printf '  TARGET_IMAGE=%s UCORE_STREAM=%s NVIDIA_TAG=%s just build\n' \
+                '{{ TARGET_IMAGE }}' '{{ UCORE_STREAM }}' '{{ NVIDIA_TAG }}' >&2
+            exit 1
+        fi
+    fi
+
+    WORK_DIR="$(mktemp -d)"
+    ROOTFS="${WORK_DIR}/rootfs"
+    CONTAINER="gen-sbom-${RANDOM}-${RANDOM}"
+    trap 'podman container rm -f "${CONTAINER}" >/dev/null 2>&1 || true; rm -rf "${WORK_DIR}"' EXIT
+
+    mkdir -p "$ROOTFS" "$(dirname "$OUTPUT")"
+    podman container create --name "$CONTAINER" "$IMAGE" >/dev/null
+    podman export "$CONTAINER" | tar --no-same-owner -C "$ROOTFS" -xf -
+
+    export SYFT_PARALLELISM="${SYFT_PARALLELISM:-$(($(nproc) * 2))}"
+    "{{ SYFT_CMD }}" --source-name "$IMAGE" "$WORK_DIR" -o "spdx-json=$OUTPUT"
+    du -sh "$OUTPUT"


### PR DESCRIPTION
Uses Syft to generate SPDX JSON SBOMs for each per-arch image during build, uploads them as workflow artifacts, then attaches each SBOM to the matching image digest via ORAS and signs the attached SBOM artifact with cosign.

The flow mirrors bluefin's approach, adapted for ucore's build architecture. Some repository level secrets may need to be set and/or generated.

Closes #365