### PR TITLE
Fix Buildah version pin in reusable build workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -566,8 +566,10 @@ jobs:
             *) printf "Invalid architecture" >&2; exit 1 ;;
           esac
 
-          echo "Installing up to date buildah for $IMAGE_ARCH"
-          curl -fsSL https://github.com/bsherman/buildah-static/releases/latest/download/buildah-${IMAGE_ARCH:?}.tar.gz \
+          # Buildah >=1.44.0 is incompatible with the ubuntu-24.04 Podman stack.
+          BUILDAH_VERSION=v1.43.1
+          echo "Installing Buildah $BUILDAH_VERSION for $IMAGE_ARCH"
+          curl -fsSL "https://github.com/bsherman/buildah-static/releases/download/${BUILDAH_VERSION}/buildah-${IMAGE_ARCH:?}.tar.gz" \
             | tar -xzf - -C /usr/local/bin/
 
           # Workaround issues between custom buildah installation and apparmor

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,23 @@
       ],
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{depName}}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/reusable-build\\.yml$/"],
+      "matchStrings": [
+        "BUILDAH_VERSION=(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "bsherman/buildah-static",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Buildah >=1.44.0 requires a newer ubuntu-24.04 Podman stack",
+      "matchPackageNames": ["bsherman/buildah-static"],
+      "allowedVersions": "<1.44.0"
     }
   ],
   "postUpgradeTasks": {


### PR DESCRIPTION
## Summary
- Pin Buildah to a compatible version in the reusable build workflow.
- Update Renovate configuration to keep the pin under control.

## Why
- A newer Buildah release caused compatibility issues in the build pipeline.
- Pinning to a known-good version restores reliable workflow execution.

## Testing
- Not run locally.
- Workflow and configuration changes were reviewed for consistency with the current build setup.