### PR TITLE
chore(ci): Tighten workflow consistency and release gating

### DIFF
--- a/.github/tests/test_sentinel_result_aggregate.py
+++ b/.github/tests/test_sentinel_result_aggregate.py
@@ -60,7 +60,7 @@ class SentinelResultAggregateTests(unittest.TestCase):
                 AGGREGATE.aggregate_results(directory, 1)
 
     def test_expected_count_uses_the_architecture_list(self) -> None:
-        self.assertEqual(AGGREGATE.expected_result_count("['aarch64', 'x86_64']"), 4)
+        self.assertEqual(AGGREGATE.expected_result_count('["aarch64", "x86_64"]'), 4)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -22,5 +22,5 @@ jobs:
     secrets: inherit
     with:
       ucore_stream: lts
-      arch: "['aarch64','x86_64']"
+      arch: '["aarch64","x86_64"]'
       force_build: ${{ github.event_name == 'workflow_dispatch' && inputs.force_build || false }}

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -22,5 +22,5 @@ jobs:
     secrets: inherit
     with:
       ucore_stream: stable
-      arch: "['aarch64','x86_64']"
+      arch: '["aarch64","x86_64"]'
       force_build: ${{ github.event_name == 'workflow_dispatch' && inputs.force_build || false }}

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -22,5 +22,5 @@ jobs:
     secrets: inherit
     with:
       ucore_stream: testing
-      arch: "['aarch64','x86_64']"
+      arch: '["aarch64","x86_64"]'
       force_build: ${{ github.event_name == 'workflow_dispatch' && inputs.force_build || false }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,28 @@
+name: check
+
+on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Formatting and unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Run checks
+        working-directory: ucore
+        run: just check

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -7,8 +7,8 @@ on:
         required: true
         type: string
       arch:
-        description: "JSON string of architectures to build, '[aarch64, x86_64]'"
-        default: "['x86_64']"
+        description: 'JSON array of architectures to build, for example ["aarch64","x86_64"]'
+        default: '["x86_64"]'
         required: false
         type: string
       force_build:
@@ -35,7 +35,6 @@ jobs:
     outputs:
       date: ${{ steps.date.outputs.date }}
       publish: ${{ steps.publish.outputs.publish }}
-      pr_prefix: ${{ steps.pr_prefix.outputs.pr_prefix }}
     steps:
       - name: Get current date
         id: date
@@ -43,20 +42,10 @@ jobs:
       - name: Determine whether to publish
         id: publish
         run: echo "publish=${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}" >> $GITHUB_OUTPUT
-      - name: Set PR Prefix
-        id: pr_prefix
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              PR_PREFIX="pr-${{ github.event.number }}-"
-          else
-              PR_PREFIX=""
-          fi
-          echo "pr_prefix=${PR_PREFIX}" >> $GITHUB_OUTPUT
       - name: Echo outputs
         run: |
           echo "${{ toJSON(steps.date.outputs) }}"
-          echo "${{ toJSON(steps.pr_prefix.outputs) }}"
+          echo "${{ toJSON(steps.publish.outputs) }}"
 
   stream_info:
     name: "Stream Info: ${{ matrix.arch }}"
@@ -87,8 +76,8 @@ jobs:
           timeout_minutes: 5
           command: |
             set -euo pipefail
-            pushd ucore
-            just stream-info ../stream-info.env
+            just --justfile ucore/Justfile --working-directory ucore \
+                stream-info ../stream-info.env
       - name: Upload stream info as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -156,7 +145,6 @@ jobs:
           AKMODS_REGISTRY: ${{ env.AKMODS_REGISTRY }}
           UCORE_STREAM: ${{ inputs.ucore_stream }}
           FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           KERNEL_FLAVOR: ${{ env.KERNEL_FLAVOR }}
           KERNEL_VERSION: ${{ env.KERNEL_VERSION }}
           NVIDIA_TAG: ${{ matrix.nvidia_tag }}
@@ -166,8 +154,8 @@ jobs:
           retry_wait_seconds: 15
           timeout_minutes: 15
           command: |
-            pushd ucore
-            just ci-prepare-build \
+            just --justfile ucore/Justfile --working-directory ucore \
+                ci-prepare-build \
                 "quay.io/fedora/fedora-coreos:${{ env.IMAGE_VERSION }}" \
                 "${{ matrix.arch }}"
 
@@ -175,18 +163,18 @@ jobs:
         env:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
-          pushd ucore
           AKMODS_REGISTRY=${{ env.AKMODS_REGISTRY }} \
           UCORE_STREAM=${{ inputs.ucore_stream }} \
           FEDORA_VERSION=${{ env.FEDORA_VERSION }} \
-          IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }} \
           KERNEL_FLAVOR=${{ env.KERNEL_FLAVOR }} \
           KERNEL_VERSION=${{ env.KERNEL_VERSION }} \
           NVIDIA_TAG=${{ matrix.nvidia_tag }} \
           TARGET_IMAGE=${{ env.IMAGE_NAME }} \
           CI_BUILD_TAG=${{ env.SENTINEL_TAG }} \
-          just build "quay.io/fedora/fedora-coreos:${{ env.IMAGE_VERSION }}"
-          just gen-sbom \
+          just --justfile ucore/Justfile --working-directory ucore \
+              build "quay.io/fedora/fedora-coreos:${{ env.IMAGE_VERSION }}"
+          just --justfile ucore/Justfile --working-directory ucore \
+              gen-sbom \
               "${{ env.IMAGE_NAME }}:${{ env.SENTINEL_TAG }}" \
               ../sentinel-sbom.json
 
@@ -270,8 +258,6 @@ jobs:
       actions: write
       contents: read
       packages: write
-    env:
-      PR_PREFIX: ${{ needs.workflow_info.outputs.pr_prefix }}
     strategy:
       fail-fast: false
       matrix:
@@ -342,7 +328,6 @@ jobs:
           AKMODS_REGISTRY: ${{ env.AKMODS_REGISTRY }}
           UCORE_STREAM: ${{ inputs.ucore_stream }}
           FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           KERNEL_FLAVOR: ${{ env.KERNEL_FLAVOR }}
           KERNEL_VERSION: ${{ env.KERNEL_VERSION }}
           NVIDIA_TAG: ${{ matrix.nvidia_tag }}
@@ -352,8 +337,8 @@ jobs:
           retry_wait_seconds: 15
           timeout_minutes: 15
           command: |
-            pushd ucore
-            just ci-prepare-build \
+            just --justfile ucore/Justfile --working-directory ucore \
+                ci-prepare-build \
                 "quay.io/fedora/fedora-coreos:${{ env.IMAGE_VERSION }}" \
                 "${{ matrix.arch }}"
 
@@ -367,7 +352,6 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
           tags: |
             ${{ env.TAG_VERSION_ARCH }}
-          build-args: |
           labels: ${{ steps.meta.outputs.labels }}
           oci: true
           extra-args: |
@@ -386,15 +370,15 @@ jobs:
         env:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
-          pushd ucore
-          just gen-sbom \
+          just --justfile ucore/Justfile --working-directory ucore \
+              gen-sbom \
               "${{ env.IMAGE_NAME }}:${TAG_VERSION_ARCH}" \
               ../sbom.json
 
       - name: Package Provenance
         run: |
-          pushd ucore
-          just package-provenance \
+          just --justfile ucore/Justfile --working-directory ucore \
+              package-provenance \
               "${{ env.IMAGE_NAME }}:${TAG_VERSION_ARCH}" \
               ../package-provenance.txt
 
@@ -420,7 +404,7 @@ jobs:
       - name: Login to GitHub Container Registry
         if: needs.workflow_info.outputs.publish == 'true'
         run: |
-          printf '%s' "${{ github.token }}" | podman login "${{ env.IMAGE_REGISTRY }}" -u "${{ github.actor }}" --password-stdin
+          printf '%s' "${{ github.token }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Push Image to Registry
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -508,7 +492,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         run: |
-          printf '%s' "${{ github.token }}" | podman login "${{ env.IMAGE_REGISTRY }}" -u "${{ github.actor }}" --password-stdin
+          printf '%s' "${{ github.token }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Set matrix environment variables
         shell: bash
@@ -531,7 +515,6 @@ jobs:
         with:
           tags: |
             type=sha,format=short,suffix=-${{ env.TAG_VERSION }}
-            type=ref,event=pr,suffix=-${{ env.TAG_VERSION }}
             type=raw,value=${{ env.TAG_VERSION }}-${{ needs.workflow_info.outputs.date }},priority=750,enable=${{ startsWith(github.ref, 'refs/heads/main') }}
             type=raw,value=${{ env.TAG_VERSION }},priority=350,enable=${{ startsWith(github.ref, 'refs/heads/main') }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/heads/main') && env.TAG_VERSION == 'stable' }}
@@ -762,8 +745,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          pushd ucore
-          just changelog \
+          just --justfile ucore/Justfile --working-directory ucore \
+              changelog \
               "${{ inputs.ucore_stream }}" \
               ../changelog.md \
               ../changelog.env \
@@ -771,7 +754,6 @@ jobs:
               20 \
               ../images \
               "${{ needs.workflow_info.outputs.date }}"
-          popd
 
           # shellcheck disable=SC1091
           source changelog.env

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,11 +36,15 @@ jobs:
       contents: read
     outputs:
       date: ${{ steps.date.outputs.date }}
+      publish: ${{ steps.publish.outputs.publish }}
       pr_prefix: ${{ steps.pr_prefix.outputs.pr_prefix }}
     steps:
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Determine whether to publish
+        id: publish
+        run: echo "publish=${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}" >> $GITHUB_OUTPUT
       - name: Set PR Prefix
         id: pr_prefix
         shell: bash
@@ -388,13 +392,13 @@ jobs:
 
       - name: Setup Syft
         id: setup-syft
-        if: github.event_name != 'pull_request'
+        if: needs.workflow_info.outputs.publish == 'true'
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           syft-version: v1.39.0
 
       - name: Generate SBOM
-        if: github.event_name != 'pull_request'
+        if: needs.workflow_info.outputs.publish == 'true'
         id: generate-sbom
         env:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
@@ -431,14 +435,14 @@ jobs:
           sbverify --cert akmods.crt vmlinuz || exit 1
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: needs.workflow_info.outputs.publish == 'true'
         run: |
           printf '%s' "${{ github.token }}" | podman login "${{ env.IMAGE_REGISTRY }}" -u "${{ github.actor }}" --password-stdin
 
       - name: Push Image to Registry
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         id: push
-        if: github.event_name != 'pull_request'
+        if: needs.workflow_info.outputs.publish == 'true'
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           BUILD_IMAGE: ${{ steps.build_image.outputs.image }}
@@ -458,7 +462,7 @@ jobs:
             echo "registry-path=$IMAGE_REGISTRY/$BUILD_IMAGE:$first_tag" >> $GITHUB_OUTPUT
 
       - name: Save image metadata
-        if: github.event_name != 'pull_request'
+        if: needs.workflow_info.outputs.publish == 'true'
         run: |
           set -x
           echo "IMAGE_ARCH=${{ matrix.arch }}" >> image.env
@@ -467,7 +471,7 @@ jobs:
           echo "${{ steps.meta.outputs.labels }}" > labels.txt
 
       - name: Upload image metadata as artifact
-        if: github.event_name != 'pull_request'
+        if: needs.workflow_info.outputs.publish == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-ucore${{ matrix.image_suffix }}${{ matrix.nvidia_tag != '' && matrix.nvidia_tag || '-default' }}-${{ matrix.arch }}
@@ -498,7 +502,7 @@ jobs:
   push_and_sign:
     name: "Push and sign: ucore${{ matrix.image_suffix }}${{ matrix.nvidia_tag }}"
     runs-on: ubuntu-24.04
-    if: needs.check_builds.result == 'success' && needs.build_image.result == 'success' && needs.sentinel_decision.outputs.changed == 'true' && !cancelled() && github.event_name != 'pull_request'
+    if: needs.check_builds.result == 'success' && needs.build_image.result == 'success' && needs.sentinel_decision.outputs.changed == 'true' && needs.workflow_info.outputs.publish == 'true' && !cancelled()
     needs: [workflow_info, sentinel_decision, check_builds, build_image]
     permissions:
       actions: read
@@ -544,9 +548,9 @@ jobs:
           tags: |
             type=sha,format=short,suffix=-${{ env.TAG_VERSION }}
             type=ref,event=pr,suffix=-${{ env.TAG_VERSION }}
-            type=raw,value=${{ env.TAG_VERSION }}-${{ needs.workflow_info.outputs.date }},priority=750,enable=${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && startsWith(github.ref, 'refs/heads/main') }}
-            type=raw,value=${{ env.TAG_VERSION }},priority=350,enable=${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && startsWith(github.ref, 'refs/heads/main') }}
-            type=raw,value=latest,enable=${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && startsWith(github.ref, 'refs/heads/main') && env.TAG_VERSION == 'stable' }}
+            type=raw,value=${{ env.TAG_VERSION }}-${{ needs.workflow_info.outputs.date }},priority=750,enable=${{ startsWith(github.ref, 'refs/heads/main') }}
+            type=raw,value=${{ env.TAG_VERSION }},priority=350,enable=${{ startsWith(github.ref, 'refs/heads/main') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/heads/main') && env.TAG_VERSION == 'stable' }}
 
       - name: Single Line (convert newlines to spaces)
         id: single-line
@@ -638,17 +642,14 @@ jobs:
 
       # Sign container
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        if: github.event_name != 'pull_request'
         with:
           cosign-release: "v2.6.1"
 
       - name: Login to GitHub Container Registry for cosign
-        if: github.event_name != 'pull_request'
         run: |
           printf '%s' "${{ github.token }}" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Sign member images
-        if: github.event_name != 'pull_request'
         shell: bash
         env:
           COSIGN_EXPERIMENTAL: false
@@ -677,7 +678,6 @@ jobs:
           done
 
       - name: Sign container manifest
-        if: github.event_name != 'pull_request'
         env:
           REGISTRY_PATH: ${{ steps.push.outputs.registry-path }}
           DIGEST: ${{ steps.push.outputs.digest }}
@@ -688,16 +688,13 @@ jobs:
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_PATH }}@${{ env.DIGEST }}
 
       - name: Install ORAS
-        if: github.event_name != 'pull_request'
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
 
       - name: Login to GitHub Container Registry with ORAS
-        if: github.event_name != 'pull_request'
         run: |
           printf '%s' "${{ github.token }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Upload SBOMs
-        if: github.event_name != 'pull_request'
         id: upload-sbom
         run: |
           set -xeuo pipefail
@@ -736,7 +733,6 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Sign SBOM OCI Artifacts
-        if: github.event_name != 'pull_request'
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
@@ -751,7 +747,7 @@ jobs:
   publish_release:
     name: Publish release notes
     runs-on: ubuntu-24.04
-    if: needs.push_and_sign.result == 'success' && !cancelled() && github.event_name != 'pull_request' && github.event_name != 'merge_group' && startsWith(github.ref, 'refs/heads/main')
+    if: needs.push_and_sign.result == 'success' && needs.workflow_info.outputs.publish == 'true' && !cancelled() && startsWith(github.ref, 'refs/heads/main')
     needs: [workflow_info, push_and_sign]
     permissions:
       contents: write

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Determine whether to publish
         id: publish
-        run: echo "publish=${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}" >> $GITHUB_OUTPUT
+        run: echo "publish=${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}" >> $GITHUB_OUTPUT
       - name: Echo outputs
         run: |
           echo "${{ toJSON(steps.date.outputs) }}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,9 +21,6 @@ on:
 env:
   AKMODS_REGISTRY: ghcr.io/ublue-os
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  # lts uses the stable CoreOS base image but with the longterm kernel
-  COREOS_STREAM: ${{ inputs.ucore_stream == 'lts' && 'stable' || inputs.ucore_stream }}
-  KERNEL_FLAVOR: ${{ inputs.ucore_stream == 'lts' && 'longterm-6.18' || format('coreos-{0}', inputs.ucore_stream == 'lts' && 'stable' || inputs.ucore_stream) }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.ucore_stream }}
@@ -66,51 +63,32 @@ jobs:
     runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' }}
     permissions:
       actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         arch: ${{ fromJson(inputs.arch) }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
       - name: Fetch CoreOS stream versions
         id: fetch
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          AKMODS_REGISTRY: ${{ env.AKMODS_REGISTRY }}
+          UCORE_STREAM: ${{ inputs.ucore_stream }}
         with:
           max_attempts: 3
           retry_wait_seconds: 15
           timeout_minutes: 5
           command: |
-            set -eo pipefail
-
-            skopeo inspect docker://quay.io/fedora/fedora-coreos:${{ env.COREOS_STREAM }} > inspect.json
-
-            image=$(jq -r '.["Labels"]["org.opencontainers.image.version"]' inspect.json)
-            if [ -z "$image" ] || [ "null" = "$image" ]; then
-              echo "inspected image version must not be empty or null" >&2
-              exit 1
-            fi
-
-            if [[ "${image}" =~ "42.20250410.3" ]]; then
-              echo "WARNING: Overriding known problematic release. Downgrading from 42.20250410.3.* to 41.20250331.3.0" >&2
-              image="41.20250331.3.0"
-            fi
-
-            fedora=$(echo "$image" | cut -f1 -d.)
-            if [ -z "$fedora" ] || [ "null" = "$fedora" ]; then
-              echo "fedora version must not be empty or null" >&2
-              exit 1
-            fi
-
-            kernel=$(skopeo inspect docker://${{ env.AKMODS_REGISTRY }}/akmods-zfs:${{ env.KERNEL_FLAVOR }}-${fedora} | jq -r '.["Labels"]["ostree.linux"]')
-            if [ -z "$kernel" ] || [ "null" = "$kernel" ]; then
-              echo "inspected linux (kernel) version must not be empty or null" >&2
-              exit 1
-            fi
-
-            echo "FEDORA_VERSION=${fedora}" > stream-info.env
-            echo "IMAGE_VERSION=${image}" >> stream-info.env
-            echo "KERNEL_VERSION=${kernel}" >> stream-info.env
-
-            cat stream-info.env
+            set -euo pipefail
+            pushd ucore
+            just stream-info ../stream-info.env
       - name: Upload stream info as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,6 +19,7 @@ on:
         type: boolean
 
 env:
+  AKMODS_REGISTRY: ghcr.io/ublue-os
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   # lts uses the stable CoreOS base image but with the longterm kernel
   COREOS_STREAM: ${{ inputs.ucore_stream == 'lts' && 'stable' || inputs.ucore_stream }}
@@ -99,7 +100,7 @@ jobs:
               exit 1
             fi
 
-            kernel=$(skopeo inspect docker://ghcr.io/ublue-os/akmods-zfs:${{ env.KERNEL_FLAVOR }}-${fedora} | jq -r '.["Labels"]["ostree.linux"]')
+            kernel=$(skopeo inspect docker://${{ env.AKMODS_REGISTRY }}/akmods-zfs:${{ env.KERNEL_FLAVOR }}-${fedora} | jq -r '.["Labels"]["ostree.linux"]')
             if [ -z "$kernel" ] || [ "null" = "$kernel" ]; then
               echo "inspected linux (kernel) version must not be empty or null" >&2
               exit 1
@@ -173,6 +174,7 @@ jobs:
       - name: Prepare image build inputs
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
+          AKMODS_REGISTRY: ${{ env.AKMODS_REGISTRY }}
           UCORE_STREAM: ${{ inputs.ucore_stream }}
           FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
@@ -195,6 +197,7 @@ jobs:
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
           pushd ucore
+          AKMODS_REGISTRY=${{ env.AKMODS_REGISTRY }} \
           UCORE_STREAM=${{ inputs.ucore_stream }} \
           FEDORA_VERSION=${{ env.FEDORA_VERSION }} \
           IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }} \
@@ -357,6 +360,7 @@ jobs:
       - name: Prepare image build inputs
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
+          AKMODS_REGISTRY: ${{ env.AKMODS_REGISTRY }}
           UCORE_STREAM: ${{ inputs.ucore_stream }}
           FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -145,6 +145,7 @@ jobs:
           set -x
           echo "IMAGE_NAME=ucore-hci" >> $GITHUB_ENV
           echo "SENTINEL_TAG=sentinel-${{ inputs.ucore_stream }}${{ matrix.nvidia_tag }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          # -nvidia-open selects the akmods source; the compatible public tag remains -nvidia.
           NVIDIA_TAG="${{ matrix.nvidia_tag }}"
           echo "PUBLISHED_TAG=${{ inputs.ucore_stream }}${NVIDIA_TAG%-open}" >> $GITHUB_ENV
           cat stream-info.env >> $GITHUB_ENV
@@ -514,6 +515,7 @@ jobs:
         run: |
           set -x
           echo "IMAGE_NAME=ucore${{ matrix.image_suffix }}" >> $GITHUB_ENV
+          # -nvidia-open selects the akmods source; the compatible public tag remains -nvidia.
           NVIDIA_TAG="${{ matrix.nvidia_tag }}"
           echo "TAG_VERSION=${{ inputs.ucore_stream }}${NVIDIA_TAG%-open}" >> $GITHUB_ENV
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
+__pycache__/
+*.py[cod]
 Containerfile
 ucore/audit

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ The [tag matrix](#tag-matrix) includes combinations of the following:
 - `nvidia` - images which include latest open nvidia driver and container runtime
 - `nvidia-lts` - images which include LTS nvidia driver and container runtime
 
+CI uses `-nvidia-open` internally to select the open-driver akmods image, then publishes that
+variant under the existing `-nvidia` tags. Local builds, per-architecture CI images, and sentinel
+candidates retain the internal selector in their temporary tags; published manifests and the
+sentinel comparison target use the public tag.
+
 ### Images
 
 #### `ucore-minimal`

--- a/ucore/Containerfile.in
+++ b/ucore/Containerfile.in
@@ -1,7 +1,7 @@
 # /* FROMs for copying */
-FROM IMAGE_REGISTRY/akmods-zfs:AKMODS_TAG AS akmods-zfs
+FROM AKMODS_REGISTRY/akmods-zfs:AKMODS_TAG AS akmods-zfs
 # ifdef NVIDIA
-FROM IMAGE_REGISTRY/akmods-NVIDIA:AKMODS_TAG AS akmods-nvidia
+FROM AKMODS_REGISTRY/akmods-NVIDIA:AKMODS_TAG AS akmods-nvidia
 # endif /* NVIDIA */
 FROM scratch AS ctx
 COPY / /

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -1,4 +1,4 @@
-set dotenv-load := true
+set dotenv-load
 
 CI_BUILD_TAG := env("CI_BUILD_TAG", "")
 export AKMODS_REGISTRY := env("AKMODS_REGISTRY", "ghcr.io/ublue-os")
@@ -16,6 +16,10 @@ export TARGET_IMAGE := env("TARGET_IMAGE", "ucore-minimal")
 
 _default:
     @just --list --unsorted
+
+check:
+    just --fmt --check
+    python3 -m unittest discover -s ../.github/tests -v
 
 upstream-version image:
     #!/usr/bin/env bash

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -38,6 +38,35 @@ upstream-image:
     version=$(just upstream-version "$image")
     printf '%s:%s\n' "$image" "$version"
 
+stream-info output='stream-info.env':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    output='{{ output }}'
+    image=$(just upstream-version quay.io/fedora/fedora-coreos)
+    fedora=${image%%.*}
+    if [ -z "$fedora" ] || [ "null" = "$fedora" ]; then
+        echo "Fedora version must not be empty or null" >&2
+        exit 1
+    fi
+
+    kernel=$(skopeo inspect \
+        "docker://{{ AKMODS_REGISTRY }}/akmods-zfs:{{ KERNEL_FLAVOR }}-${fedora}" | \
+        jq -r '.["Labels"]["ostree.linux"]')
+    if [ -z "$kernel" ] || [ "null" = "$kernel" ]; then
+        echo "inspected linux kernel version must not be empty or null" >&2
+        exit 1
+    fi
+
+    {
+        printf 'COREOS_STREAM=%s\n' '{{ COREOS_STREAM }}'
+        printf 'KERNEL_FLAVOR=%s\n' '{{ KERNEL_FLAVOR }}'
+        printf 'FEDORA_VERSION=%s\n' "$fedora"
+        printf 'IMAGE_VERSION=%s\n' "$image"
+        printf 'KERNEL_VERSION=%s\n' "$kernel"
+    } > "$output"
+    cat "$output"
+
 containerfile upstream_image='':
     #!/usr/bin/env bash
     set -euo pipefail

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -1,40 +1,52 @@
 set dotenv-load := true
 
 CI_BUILD_TAG := env("CI_BUILD_TAG", "")
-UCORE_STREAM := env("UCORE_STREAM", "stable")
-FEDORA_VERSION := env("FEDORA_VERSION", "44")
-IMAGE_REGISTRY := env("IMAGE_REGISTRY", "ghcr.io/ublue-os")
+export UCORE_STREAM := env("UCORE_STREAM", "stable")
+export FEDORA_VERSION := env("FEDORA_VERSION", "44")
+export IMAGE_REGISTRY := env("IMAGE_REGISTRY", "ghcr.io/ublue-os")
 # lts uses stable CoreOS base with longterm kernel; stable and testing use stock coreos kernel
 COREOS_STREAM := if UCORE_STREAM == 'lts' { 'stable' } else { UCORE_STREAM }
-KERNEL_FLAVOR := env("KERNEL_FLAVOR", if UCORE_STREAM == 'lts' { "longterm-6.18" } else { 'coreos-' + COREOS_STREAM })
-KERNEL_VERSION := env("KERNEL_VERSION", "")
-NVIDIA_TAG := env("NVIDIA_TAG", "")
+export KERNEL_FLAVOR := env("KERNEL_FLAVOR", if UCORE_STREAM == 'lts' { "longterm-6.18" } else { 'coreos-' + COREOS_STREAM })
+export KERNEL_VERSION := env("KERNEL_VERSION", "")
+export NVIDIA_TAG := env("NVIDIA_TAG", "")
 SELINUX := path_exists('/sys/fs/selinux')
 SYFT_CMD := env("SYFT_CMD", "syft")
-TARGET_IMAGE := env("TARGET_IMAGE", "ucore-minimal")
+export TARGET_IMAGE := env("TARGET_IMAGE", "ucore-minimal")
 
 _default:
     @just --list --unsorted
 
 upstream-version image:
     #!/usr/bin/env bash
-    version=$(skopeo inspect docker://"{{ image }}":{{ COREOS_STREAM }} | \
+    set -euo pipefail
+
+    image='{{ image }}'
+    version=$(skopeo inspect "docker://${image}:{{ COREOS_STREAM }}" | \
             jq -r '.["Labels"]["org.opencontainers.image.version"]')
     if [ -z "$version" ] || [ "null" = "$version" ]; then
-      echo "inspected image ({{ image }}) version must not be empty or null" >&2
+      echo "inspected image ($image) version must not be empty or null" >&2
       exit 1
     fi
-    echo "$version"
+    printf '%s\n' "$version"
 
 upstream-image:
     #!/usr/bin/env bash
+    set -euo pipefail
+
     image='quay.io/fedora/fedora-coreos'
-    version=$(just upstream-version $image)
-    echo "$image:$version"
+    version=$(just upstream-version "$image")
+    printf '%s:%s\n' "$image" "$version"
 
 containerfile upstream_image='':
     #!/usr/bin/env bash
+    set -euo pipefail
     set -x
+
+    UPSTREAM_IMAGE='{{ upstream_image }}'
+    if [ -z "$UPSTREAM_IMAGE" ]; then
+        UPSTREAM_IMAGE="$(just upstream-image)"
+    fi
+
     KERNEL_VERSION=""
     if [ -n "{{ KERNEL_VERSION }}" ]; then
         KERNEL_VERSION="-{{ KERNEL_VERSION }}"
@@ -45,7 +57,7 @@ containerfile upstream_image='':
       "-DUCORE={{ UCORE_STREAM }}"
       "-DIMAGE_REGISTRY={{ IMAGE_REGISTRY }}"
       "-DKERNEL={{ KERNEL_FLAVOR }}"
-      "-DUPSTREAM_IMAGE={{ if upstream_image == '' { shell('just upstream-image') } else { upstream_image } }}"
+      "-DUPSTREAM_IMAGE=${UPSTREAM_IMAGE}"
     )
     if [ -n "$NVIDIA_TAG" ]; then
       # NVIDIA_TAG=={{ NVIDIA_TAG }}
@@ -60,15 +72,17 @@ containerfile upstream_image='':
 
 build upstream_image='':
     #!/usr/bin/env bash
+    set -euo pipefail
     set -x
-    just containerfile {{ upstream_image }}
+
+    just containerfile "{{ upstream_image }}"
     # TODO: use LABELS_FILE to include labels in image
-    BUILD_TAG={{ CI_BUILD_TAG }}
+    BUILD_TAG='{{ CI_BUILD_TAG }}'
     if [ -z "$BUILD_TAG" ]; then
-        BUILD_TAG={{ UCORE_STREAM }}{{ NVIDIA_TAG }}
+        BUILD_TAG='{{ UCORE_STREAM }}{{ NVIDIA_TAG }}'
     fi
     podman build -f Containerfile \
-        --target {{ TARGET_IMAGE }} \
+        --target "{{ TARGET_IMAGE }}" \
         -t "{{ TARGET_IMAGE }}:${BUILD_TAG}" .
 
 ci-prepare-build upstream_image='' arch='':

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -10,7 +10,6 @@ COREOS_STREAM := if UCORE_STREAM == 'lts' { 'stable' } else { UCORE_STREAM }
 export KERNEL_FLAVOR := env("KERNEL_FLAVOR", if UCORE_STREAM == 'lts' { "longterm-6.18" } else { 'coreos-' + COREOS_STREAM })
 export KERNEL_VERSION := env("KERNEL_VERSION", "")
 export NVIDIA_TAG := env("NVIDIA_TAG", "")
-SELINUX := path_exists('/sys/fs/selinux')
 SYFT_CMD := env("SYFT_CMD", "syft")
 export TARGET_IMAGE := env("TARGET_IMAGE", "ucore-minimal")
 
@@ -94,7 +93,6 @@ containerfile upstream_image='':
       "-DUPSTREAM_IMAGE=${UPSTREAM_IMAGE}"
     )
     if [ -n "$NVIDIA_TAG" ]; then
-      # NVIDIA_TAG=={{ NVIDIA_TAG }}
       CPP_FLAGS+=(
         "-DNVIDIA=${NVIDIA_TAG#-}"
       )

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -41,6 +41,7 @@ upstream-image:
     version=$(just upstream-version "$image")
     printf '%s:%s\n' "$image" "$version"
 
+# Emergency CoreOS image-version override: https://github.com/ublue-os/ucore/issues/413
 stream-info output='stream-info.env':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -102,6 +103,7 @@ containerfile upstream_image='':
     cpp -E -P "${CPP_FLAGS[@]}" Containerfile.in -o Containerfile
     cat Containerfile
 
+# Sandbox end-to-end publication testing: https://github.com/ublue-os/ucore/issues/414
 build upstream_image='':
     #!/usr/bin/env bash
     set -euo pipefail

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -1,6 +1,7 @@
 set dotenv-load := true
 
 CI_BUILD_TAG := env("CI_BUILD_TAG", "")
+export AKMODS_REGISTRY := env("AKMODS_REGISTRY", "ghcr.io/ublue-os")
 export UCORE_STREAM := env("UCORE_STREAM", "stable")
 export FEDORA_VERSION := env("FEDORA_VERSION", "44")
 export IMAGE_REGISTRY := env("IMAGE_REGISTRY", "ghcr.io/ublue-os")
@@ -54,8 +55,8 @@ containerfile upstream_image='':
     declare -a CPP_FLAGS
     CPP_FLAGS+=(
       "-DAKMODS_TAG={{ KERNEL_FLAVOR }}-{{ FEDORA_VERSION }}${KERNEL_VERSION}"
+      "-DAKMODS_REGISTRY={{ AKMODS_REGISTRY }}"
       "-DUCORE={{ UCORE_STREAM }}"
-      "-DIMAGE_REGISTRY={{ IMAGE_REGISTRY }}"
       "-DKERNEL={{ KERNEL_FLAVOR }}"
       "-DUPSTREAM_IMAGE=${UPSTREAM_IMAGE}"
     )
@@ -116,11 +117,11 @@ ci-prepare-build upstream_image='' arch='':
         just verify-checksum "" "{{ FEDORA_VERSION }}" "$ARCH"
     fi
 
-    AKMODS_ZFS="{{ IMAGE_REGISTRY }}/akmods-zfs:{{ KERNEL_FLAVOR }}-{{ FEDORA_VERSION }}-{{ KERNEL_VERSION }}"
+    AKMODS_ZFS="{{ AKMODS_REGISTRY }}/akmods-zfs:{{ KERNEL_FLAVOR }}-{{ FEDORA_VERSION }}-{{ KERNEL_VERSION }}"
     podman pull "$UPSTREAM_IMAGE"
     podman pull "$AKMODS_ZFS"
     if [ -n "{{ NVIDIA_TAG }}" ]; then
-        AKMODS_NVIDIA="{{ IMAGE_REGISTRY }}/akmods{{ NVIDIA_TAG }}:{{ KERNEL_FLAVOR }}-{{ FEDORA_VERSION }}-{{ KERNEL_VERSION }}"
+        AKMODS_NVIDIA="{{ AKMODS_REGISTRY }}/akmods{{ NVIDIA_TAG }}:{{ KERNEL_FLAVOR }}-{{ FEDORA_VERSION }}-{{ KERNEL_VERSION }}"
         podman pull "$AKMODS_NVIDIA"
     fi
 

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -41,7 +41,7 @@ upstream-image:
     version=$(just upstream-version "$image")
     printf '%s:%s\n' "$image" "$version"
 
-# Emergency CoreOS image-version override: https://github.com/ublue-os/ucore/issues/413
+# Planned emergency CoreOS image-version override: https://github.com/ublue-os/ucore/issues/413
 stream-info output='stream-info.env':
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
## Summary
- Centralize stream discovery in `just` and make image recipe failures fail closed
- Clean up workflow inputs/calls and restrict publishing to release events
- Add lightweight CI quality checks plus docs updates for NVIDIA tag normalization and CI follow-ups

## Why
- Keeps build, check, and reusable workflow behavior aligned across stable, testing, and LTS jobs
- Reduces accidental publishing and makes failures more explicit during image recipe evaluation
- Improves maintainability by moving repeated stream logic into one place and documenting the workflow conventions

## Testing
- Added/updated lightweight sentinel and quality checks in `.github/tests/test_sentinel_result_aggregate.py`
- Verified workflow and `just` changes through the updated CI configuration
- Documentation-only changes reviewed for consistency with the new behavior

Follow-ups: #413, #414