### PR TITLE
refactor(ci): use ucore for scheduled release sentinel

### DIFF
--- a/.github/workflows/build-lts.yml
+++ b/.github/workflows/build-lts.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       force_build:
-        description: "Bypass RPM-only sentinel package-diff gate for non-RPM changes"
+        description: "Force full build for non-RPM or HCI-only changes"
         default: true
         required: false
         type: boolean

--- a/.github/workflows/build-stable.yml
+++ b/.github/workflows/build-stable.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       force_build:
-        description: "Bypass RPM-only sentinel package-diff gate for non-RPM changes"
+        description: "Force full build for non-RPM or HCI-only changes"
         default: true
         required: false
         type: boolean

--- a/.github/workflows/build-testing.yml
+++ b/.github/workflows/build-testing.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       force_build:
-        description: "Bypass RPM-only sentinel package-diff gate for non-RPM changes"
+        description: "Force full build for non-RPM or HCI-only changes"
         default: true
         required: false
         type: boolean

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
       force_build:
         description: >-
-          Bypass the RPM-only sentinel package-diff gate and run the full build for non-RPM changes
+          Force a full build for non-RPM or HCI-only changes, bypassing the RPM-only sentinel package-diff gate
         default: false
         required: false
         type: boolean
@@ -87,7 +87,7 @@ jobs:
           retention-days: 7
 
   sentinel_build:
-    name: "Sentinel: ucore-hci${{ matrix.nvidia_tag }}: ${{ matrix.arch }}"
+    name: "Sentinel: ucore${{ matrix.nvidia_tag }}: ${{ matrix.arch }}"
     if: (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.force_build)) && !cancelled()
     needs: [stream_info]
     runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' }}
@@ -162,7 +162,8 @@ jobs:
         shell: bash
         run: |
           set -x
-          echo "IMAGE_NAME=ucore-hci" >> $GITHUB_ENV
+          # Ignore HCI-only churn; shared ucore packages still gate releases.
+          echo "IMAGE_NAME=ucore" >> $GITHUB_ENV
           echo "SENTINEL_TAG=sentinel-${{ inputs.ucore_stream }}${{ matrix.nvidia_tag }}-${{ matrix.arch }}" >> $GITHUB_ENV
           # -nvidia-open selects the akmods source; the compatible public tag remains -nvidia.
           NVIDIA_TAG="${{ matrix.nvidia_tag }}"
@@ -276,7 +277,8 @@ jobs:
           if [[ "${aggregate_changed}" == "true" ]]; then
               echo "Sentinel detected package changes; running full build."
           else
-              echo "No sentinel package changes detected; skipping full build."
+              echo "No ucore sentinel package changes detected; skipping full build." \
+                  "HCI-only changes require a manual force build."
           fi
 
   build_image:

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ oras discover \
 
 [GitHub Releases](https://github.com/ublue-os/ucore/releases) provide generated changelogs for `stable`, `testing`, and `lts`. Release tags use the stream and date, such as `stable-YYYYMMDD`. `stable` is marked as the latest release; `testing` and `lts` are not.
 
-Releases are published after successful full image builds from `main`. Scheduled builds without RPM changes do not publish a release. Manual workflow runs can publish one, and a later build on the same day updates that day's release.
+Releases are published after successful full image builds from `main`. Scheduled builds without RPM changes do not publish a release. The scheduled sentinel tracks `ucore`, so changes exclusive to `ucore-hci` are included with the next shared update. Maintainers can publish an HCI-only update by manually running the relevant stream workflow with `force_build` enabled. A later build on the same day updates that day's release.
 
 Each changelog includes major package versions, build metadata, source comparison links, and SBOM-derived RPM additions, removals, and upgrades. Changes are grouped by image family, NVIDIA variant, and architecture where needed. The release also includes commands to rebase to either the moving stream tag or that day's exact image tag.
 


### PR DESCRIPTION
## Summary
- build and compare `ucore` rather than `ucore-hci` in the scheduled sentinel
- document that HCI-only updates require a manual `force_build` release
- clarify `force_build` descriptions for each stream workflow

## Validation
- `cd ucore && just check`
- scoped `yamllint` validation
- `git diff --check`