### PR TITLE
fix(ci): harden container builds against runner regressions

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -106,6 +106,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Configure OCI runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Runner image: ${ImageOS:-unknown} ${ImageVersion:-unknown}"
+          podman --version
+          if [[ -x /usr/bin/crun ]]; then
+              /usr/bin/crun --version
+          fi
+          if [[ -x /usr/local/bin/crun ]]; then
+              /usr/local/bin/crun --version
+          fi
+
+          runtime_path="$(podman info --format '{{.Host.OCIRuntime.Path}}')"
+          echo "Selected OCI runtime: ${runtime_path}"
+          # The 20260726 runner image pairs Podman 5.x with stale crun 1.14.1.
+          if [[ "${runtime_path}" == "/usr/bin/crun" && -x /usr/local/bin/crun ]]; then
+              sudo install -d -m 755 /etc/containers/containers.conf.d
+              printf '[engine.runtimes]\ncrun = ["/usr/local/bin/crun"]\n' \
+                  | sudo tee /etc/containers/containers.conf.d/00-fix-runtime.conf >/dev/null
+
+              runtime_path="$(podman info --format '{{.Host.OCIRuntime.Path}}')"
+              echo "Selected OCI runtime after workaround: ${runtime_path}"
+              if [[ "${runtime_path}" != "/usr/local/bin/crun" ]]; then
+                  echo "Failed to select /usr/local/bin/crun" >&2
+                  exit 1
+              fi
+          fi
+
       - name: Setup Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
@@ -280,6 +310,36 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Configure OCI runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Runner image: ${ImageOS:-unknown} ${ImageVersion:-unknown}"
+          podman --version
+          if [[ -x /usr/bin/crun ]]; then
+              /usr/bin/crun --version
+          fi
+          if [[ -x /usr/local/bin/crun ]]; then
+              /usr/local/bin/crun --version
+          fi
+
+          runtime_path="$(podman info --format '{{.Host.OCIRuntime.Path}}')"
+          echo "Selected OCI runtime: ${runtime_path}"
+          # The 20260726 runner image pairs Podman 5.x with stale crun 1.14.1.
+          if [[ "${runtime_path}" == "/usr/bin/crun" && -x /usr/local/bin/crun ]]; then
+              sudo install -d -m 755 /etc/containers/containers.conf.d
+              printf '[engine.runtimes]\ncrun = ["/usr/local/bin/crun"]\n' \
+                  | sudo tee /etc/containers/containers.conf.d/00-fix-runtime.conf >/dev/null
+
+              runtime_path="$(podman info --format '{{.Host.OCIRuntime.Path}}')"
+              echo "Selected OCI runtime after workaround: ${runtime_path}"
+              if [[ "${runtime_path}" != "/usr/local/bin/crun" ]]; then
+                  echo "Failed to select /usr/local/bin/crun" >&2
+                  exit 1
+              fi
+          fi
 
       - name: Setup Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/ucore/github-pkgs.sh
+++ b/ucore/github-pkgs.sh
@@ -52,7 +52,7 @@ get_curl_auth_args() {
 download_file() {
 	local url=${1}
 	local suffix=${2:-}
-	local -a curl_args=(curl --fail --retry 5 --retry-delay 5 --retry-all-errors -sSL)
+	local -a curl_args=(curl --fail --retry 12 --retry-max-time 300 --retry-all-errors -sSL)
 
 	create_temp_file "${suffix}"
 


### PR DESCRIPTION
## Summary
- Prefer the bundled crun when a GitHub Ubuntu runner selects the incompatible system runtime.
- Log the runner image and selected runtime before sentinel and image builds.
- Use bounded exponential retries for GitHub-sourced package artifacts.

## Validation
- `cd ucore && just check`
- `bash -n ucore/github-pkgs.sh`
- `./github-pkgs.sh verify-checksum mergerfs --release 44 --arch x86_64`
- `actionlint -ignore 'SC[0-9]+' .github/workflows/reusable-build.yml`

The unfiltered actionlint run reports only existing ShellCheck advisories elsewhere in the workflow.