### PR TITLE
fix(nvidia): work around aarch64 selinux policy-store EXDEV/ENOTEMPTY failure

### DIFF
--- a/ucore/install-ucore-minimal-nvidia.sh
+++ b/ucore/install-ucore-minimal-nvidia.sh
@@ -34,6 +34,14 @@ dnf -y install --setopt=install_weak_deps=False \
 # disable repos provided by ublue-os-nvidia-addons
 dnf5 config-manager setopt "$NVREPO".enabled=0 nvidia-container-toolkit.enabled=0
 
-semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
+# work around intermittent aarch64 overlayfs EXDEV/ENOTEMPTY failures in the
+# semodule policy-store transaction (mainly nvidia-lts:aarch64) by forcing
+# /etc/selinux/targeted fully into this layer first, so the transaction's
+# directory renames stay within a single layer.
+cp -a /etc/selinux/targeted /etc/selinux/targeted.rebuilt
+rm -rf /etc/selinux/targeted
+mv /etc/selinux/targeted.rebuilt /etc/selinux/targeted
+
+semodule --verbose --noreload --install /usr/share/selinux/packages/nvidia-container.pp
 
 systemctl enable ublue-nvctk-cdi.service


### PR DESCRIPTION
## Problem
`semodule --install` of the NVIDIA Container Toolkit SELinux policy
intermittently fails on aarch64 (mainly `nvidia-lts`, all three image
tiers) with `libsemanage.semanage_commit_sandbox: Error while renaming
.../tmp to .../active. (Directory not empty)`.

Root cause: the policy-store transaction's `rename(2)` calls cross an
overlayfs layer boundary (`active`/`previous` can still be backed by a
lower, already-committed layer while `tmp` is created fresh in the RUN
step's writable layer). That returns `EXDEV`, triggering libsemanage's
non-atomic copy fallback, which doesn't reliably leave the source
directory empty, so the commit rename then fails with `ENOTEMPTY`.
Confirmed intermittent; `nvidia-open` and x86_64 stay green.

## Fix
Force `/etc/selinux/targeted` fully into the current layer before
`semodule` so the transaction's renames stay within one layer, and add
`--noreload` (the build host has no active SELinux policy to reload).

## Validation
Native aarch64 local builds of `lts` + `nvidia-lts` and `lts` +
`nvidia-open`: both complete, pass `bootc container lint`, and
`semodule -l` confirms the `nvidia-container` module in the committed
store.

Authoritative confirmation still requires a CI aarch64 rerun of the
affected `nvidia-lts:aarch64` cells.