### PR TITLE
fix(nvidia): install matching local driver RPMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ If you installed an image with `-nvidia` in the tag, the nvidia kernel module, b
 
 Note, this does NOT add desktop graphics services to your images, but it DOES enable your compatible nvidia GPU to be used for nvdec, nvenc, CUDA, etc. Since this is CoreOS and it's primarily intended for container workloads the [nvidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/index.html) should be well understood.
 
-The included driver is the [latest nvidia driver](https://github.com/negativo17/nvidia-driver/blob/master/nvidia-driver.spec) as bundled by [negativo17](https://negativo17.org/nvidia-driver/). This package was chosen over rpmfusion's due to it's granular packages which allow us to install just the minimal `nvidia-driver-cuda` packages.
+The included driver is the [latest nvidia driver](https://github.com/negativo17/nvidia-driver/blob/master/nvidia-driver.spec) as bundled by [negativo17](https://negativo17.org/nvidia-driver/). Driver packages are installed from the same prebuilt akmods snapshot as the kernel module so their versions remain compatible.
 
 #### Other Drivers
 

--- a/ucore/install-ucore-minimal-nvidia.sh
+++ b/ucore/install-ucore-minimal-nvidia.sh
@@ -12,27 +12,67 @@ dnf5 -y swap --repo='fedora' \
 
 dnf -y install \
     /tmp/rpms/akmods-nvidia/ublue-os/ublue-os-nvidia-addons*.rpm
-# enable repos provided by ublue-os-nvidia-addons based on which is being installed
-NVREPO=fedora-nvidia
-if [[ "$NVIDIA_FLAVOR" =~ lts ]]; then
-    NVREPO=fedora-nvidia-lts
-fi
-dnf5 config-manager setopt "$NVREPO".enabled=1 nvidia-container-toolkit.enabled=1
 
-dnf -y install --setopt=install_weak_deps=False \
+# Install the driver snapshot that was used to build the kmod. Mixing it with
+# mutable NVIDIA repositories can otherwise pull an incompatible akmod.
+# nvidia-driver-selinux is only published by the regular NVIDIA repository,
+# including for LTS builds. All version-coupled packages remain local below.
+dnf5 config-manager setopt fedora-nvidia.enabled=1
+dnf -y install --setopt=install_weak_deps=False nvidia-driver-selinux
+dnf5 config-manager setopt fedora-nvidia.enabled=0
+
+ARCH="$(rpm -E '%{_arch}')"
+shopt -s nullglob
+CUDA_RPMS=(
+    /tmp/rpms/akmods-nvidia/nvidia/nvidia-driver-cuda-[0-9]*."${ARCH}".rpm
+    /tmp/rpms/akmods-nvidia/nvidia/nvidia-driver-cuda-libs-[0-9]*."${ARCH}".rpm
+    /tmp/rpms/akmods-nvidia/nvidia/nvidia-kmod-common-[0-9]*.noarch.rpm
+    /tmp/rpms/akmods-nvidia/nvidia/nvidia-modprobe-[0-9]*."${ARCH}".rpm
+    /tmp/rpms/akmods-nvidia/nvidia/nvidia-persistenced-[0-9]*."${ARCH}".rpm
+)
+KMOD_RPMS=(
     /tmp/rpms/akmods-nvidia/kmods/kmod-nvidia*.rpm
+)
+COMMON_RPMS=(
+    /tmp/rpms/akmods-nvidia/nvidia/nvidia-driver-common-[0-9]*."${ARCH}".rpm
+)
+if [[ ${#COMMON_RPMS[@]} -gt 0 ]]; then
+    CUDA_RPMS+=("${COMMON_RPMS[@]}")
+    EXPECTED_CUDA_RPMS=6
+else
+    SPLIT_COMMON_RPMS=(
+        /tmp/rpms/akmods-nvidia/nvidia/libnvidia-cfg-[0-9]*."${ARCH}".rpm
+        /tmp/rpms/akmods-nvidia/nvidia/libnvidia-gpucomp-[0-9]*."${ARCH}".rpm
+        /tmp/rpms/akmods-nvidia/nvidia/libnvidia-ml-[0-9]*."${ARCH}".rpm
+    )
+    CUDA_RPMS+=("${SPLIT_COMMON_RPMS[@]}")
+    EXPECTED_CUDA_RPMS=8
+fi
+if [[ ${#CUDA_RPMS[@]} -ne ${EXPECTED_CUDA_RPMS} || ${#KMOD_RPMS[@]} -eq 0 ]]; then
+    echo "Missing NVIDIA CUDA runtime or kmod RPMs for ${ARCH}" >&2
+    exit 1
+fi
+dnf -y install --setopt=install_weak_deps=False \
+    "${CUDA_RPMS[@]}" "${KMOD_RPMS[@]}"
 
 # hack required until nvidia-container-toolkit and dnf6 (fedora43) are playing nice
 # per: https://github.com/NVIDIA/nvidia-container-toolkit/issues/1307#issuecomment-3486656389
+dnf5 config-manager setopt nvidia-container-toolkit.enabled=1
 echo "%_pkgverify_level none" >/etc/rpm/macros.verify
 dnf -y install --setopt=install_weak_deps=False \
     nvidia-container-toolkit
 rm /etc/rpm/macros.verify
-dnf -y install --setopt=install_weak_deps=False \
-    nvidia-driver-cuda
 
-# disable repos provided by ublue-os-nvidia-addons
-dnf5 config-manager setopt "$NVREPO".enabled=0 nvidia-container-toolkit.enabled=0
+dnf5 config-manager setopt nvidia-container-toolkit.enabled=0
+
+if [[ "$(rpm -q --qf '%{VERSION}' kmod-nvidia)" != "$(rpm -q --qf '%{VERSION}' nvidia-driver-cuda)" ]]; then
+    echo "Installed NVIDIA kmod and CUDA driver versions do not match" >&2
+    exit 1
+fi
+if rpm -q akmod-nvidia >/dev/null; then
+    echo "akmod-nvidia must not be installed in the image" >&2
+    exit 1
+fi
 
 # work around intermittent aarch64 overlayfs EXDEV/ENOTEMPTY failures in the
 # semodule policy-store transaction (mainly nvidia-lts:aarch64) by forcing


### PR DESCRIPTION
## Summary
Install CUDA driver RPMs from the prebuilt akmods snapshot, preventing driver and kmod version skew without pulling desktop-oriented NVIDIA packages.

The NVIDIA repository is used only for the version-independent `nvidia-driver-selinux` policy module; all version-coupled driver and kmod RPMs are local.

## Validation
- `just check`
- Local `ucore-minimal:stable-nvidia-open` build
- Local `ucore-minimal:lts-nvidia-lts` build
- Confirmed CUDA, NVDEC, NVENC, and `nvidia-smi` are present
- Confirmed desktop/Xorg NVIDIA packages and `akmod-nvidia` are absent