### PR TITLE
fix(nvidia): enable nvidia-cdi-refresh and nvidia-persistenced explicitly

### DIFF
--- a/ucore/install-ucore-minimal-nvidia.sh
+++ b/ucore/install-ucore-minimal-nvidia.sh
@@ -84,4 +84,4 @@ mv /etc/selinux/targeted.rebuilt /etc/selinux/targeted
 
 semodule --verbose --noreload --install /usr/share/selinux/packages/nvidia-container.pp
 
-systemctl enable ublue-nvctk-cdi.service
+systemctl enable nvidia-cdi-refresh.service nvidia-cdi-refresh.path nvidia-persistenced.service


### PR DESCRIPTION
## Summary
- Companion to [ublue-os/akmods#565](https://github.com/ublue-os/akmods/pull/565), which retires `ublue-nvctk-cdi.service` in favor of upstream `nvidia-cdi-refresh.service`/`.path` and fixes the `nvidia-persistenced` boot race from #419
- The RPMs' own postinstall enable logic doesn't run reliably inside an offline container build, so enable `nvidia-cdi-refresh.service`/`.path` directly instead of trusting the package scriptlets, same as the previous `ublue-nvctk-cdi.service` handling
- Also enable `nvidia-persistenced.service` directly: on the `nvidia-lts` driver flavor it wasn't getting enabled on its own during the build (`nvidia-open` enabled it fine). `nvidia-powerd` is intentionally left alone since it's a laptop-only Dynamic Boost daemon, not relevant to ucore's server/HCI target hardware

## Test plan
- [x] Built `ucore-minimal:lts-nvidia-lts` (nvidia-lts) and `ucore-minimal:lts-nvidia` (nvidia-open) locally against this branch + the companion akmods branch, both on the `longterm-6.18` kernel
- [x] Confirmed `nvidia-persistenced.service`/`nvidia-cdi-refresh.service`/`.path` show `enabled` in both flavors without any manual workaround
- [x] Verified across multiple reboots on real NVIDIA hardware: `nvidia-persistenced.service` comes up `active (running)`, correctly ordered after `nvidia-cdi-refresh.service`, no `ConditionPathExistsGlob` skip
- Closes #419