### PR TITLE
fix(changelog): stop dropping RPM changes that aren't identical everywhere

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -961,7 +961,8 @@ def render_tiered_diffs(
         )
     )
 
-    nvidia_specific = nvidia_specific_diffs(variant_diffs, displayed_common)
+    nvidia_open_specific, nvidia_lts_specific = nvidia_specific_diffs(variant_diffs, displayed_common)
+    nvidia_specific = union_diffs([nvidia_open_specific, nvidia_lts_specific])
     if nvidia_specific:
         sample_ref = refs_by_variant[Variant("ucore", "uCore", "-nvidia")]
         lines.extend(
@@ -974,20 +975,32 @@ def render_tiered_diffs(
             )
         )
 
-    shown = union_diffs([displayed_common, nvidia_specific])
-    lines.extend(render_flavor_specific_diffs(refs_by_variant, variant_diffs, shown))
+    shown_by_variant = {}
+    for variant in VARIANTS:
+        shown = [minimal_common]
+        if variant.image_name in ("ucore", "ucore-hci"):
+            shown.append(ucore_increment)
+        if variant.image_name == "ucore-hci":
+            shown.append(hci_increment)
+        if variant.tag_suffix == "-nvidia":
+            shown.append(nvidia_open_specific)
+        elif variant.tag_suffix == "-nvidia-lts":
+            shown.append(nvidia_lts_specific)
+        shown_by_variant[variant] = union_diffs(shown)
+
+    lines.extend(render_flavor_specific_diffs(refs_by_variant, variant_diffs, shown_by_variant))
     return lines
 
 
 def render_flavor_specific_diffs(
     refs_by_variant: dict[Variant, ImageRef],
     variant_diffs: dict[Variant, dict[str, PackageDiff]],
-    shown: dict[str, PackageDiff],
+    shown_by_variant: dict[Variant, dict[str, PackageDiff]],
 ) -> list[str]:
     """Surface changes intersect_diffs dropped for not being uniform across a whole tier/flavor."""
     leftovers: dict[Variant, dict[str, PackageDiff]] = {}
     for variant in VARIANTS:
-        leftover = subtract_diffs(variant_diffs[variant], shown)
+        leftover = subtract_diffs(variant_diffs[variant], shown_by_variant[variant])
         if not leftover:
             continue
         # subtract_diffs drops arches whose residue is empty; without padding to the
@@ -1032,14 +1045,16 @@ def diff_signature(diff_by_arch: dict[str, PackageDiff]) -> dict[str, tuple[froz
 def nvidia_specific_diffs(
     variant_diffs: dict[Variant, dict[str, PackageDiff]],
     displayed_common: dict[str, PackageDiff],
-) -> dict[str, PackageDiff]:
-    nvidia_common = union_diffs(
-        [
-            intersect_diffs([variant_diffs[variant] for variant in variants_for(tag_suffix="-nvidia")]),
-            intersect_diffs([variant_diffs[variant] for variant in variants_for(tag_suffix="-nvidia-lts")]),
-        ]
+) -> tuple[dict[str, PackageDiff], dict[str, PackageDiff]]:
+    open_specific = subtract_diffs(
+        intersect_diffs([variant_diffs[variant] for variant in variants_for(tag_suffix="-nvidia")]),
+        displayed_common,
     )
-    return subtract_diffs(nvidia_common, displayed_common)
+    lts_specific = subtract_diffs(
+        intersect_diffs([variant_diffs[variant] for variant in variants_for(tag_suffix="-nvidia-lts")]),
+        displayed_common,
+    )
+    return open_specific, lts_specific
 
 
 def render_rebase(current_date: str) -> list[str]:

--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -973,7 +973,60 @@ def render_tiered_diffs(
                 empty_message="No further RPM changes detected.",
             )
         )
+
+    shown = union_diffs([displayed_common, nvidia_specific])
+    lines.extend(render_flavor_specific_diffs(refs_by_variant, variant_diffs, shown))
     return lines
+
+
+def render_flavor_specific_diffs(
+    refs_by_variant: dict[Variant, ImageRef],
+    variant_diffs: dict[Variant, dict[str, PackageDiff]],
+    shown: dict[str, PackageDiff],
+) -> list[str]:
+    """Surface changes intersect_diffs dropped for not being uniform across a whole tier/flavor."""
+    leftovers: dict[Variant, dict[str, PackageDiff]] = {}
+    for variant in VARIANTS:
+        leftover = subtract_diffs(variant_diffs[variant], shown)
+        if not leftover:
+            continue
+        # subtract_diffs drops arches whose residue is empty; without padding to the
+        # full ARCH_ORDER, a single-arch leftover looks "common" to render_diff and
+        # prints with no arch qualifier, implying it applies to every architecture.
+        for arch in ARCH_ORDER:
+            leftover.setdefault(arch, PackageDiff(added=[], removed=[], changed=[]))
+        leftovers[variant] = leftover
+
+    lines: list[str] = []
+    rendered: set[Variant] = set()
+    for variant in VARIANTS:
+        if variant not in leftovers or variant in rendered:
+            continue
+        # Group variants whose leftover is byte-identical (e.g. a change that landed
+        # on ucore-nvidia and was inherited unchanged into ucore-hci-nvidia) so it's
+        # attributed to all of them in one section instead of only the first match.
+        group = [
+            other
+            for other in VARIANTS
+            if other in leftovers and diff_signature(leftovers[other]) == diff_signature(leftovers[variant])
+        ]
+        rendered.update(group)
+
+        title = " / ".join(member.section_name for member in group) + " — Additional Changes"
+        ref = refs_by_variant[variant]
+        lines.extend(render_diff(title, ref, ref.previous_dated_tag, leftovers[variant]))
+    return lines
+
+
+def diff_signature(diff_by_arch: dict[str, PackageDiff]) -> dict[str, tuple[frozenset, frozenset, frozenset]]:
+    return {
+        arch: (
+            frozenset(entry.render() for entry in diff.added),
+            frozenset(entry.render() for entry in diff.removed),
+            frozenset(entry.render() for entry in diff.changed),
+        )
+        for arch, diff in diff_by_arch.items()
+    }
 
 
 def nvidia_specific_diffs(

--- a/.github/tests/test_changelogs.py
+++ b/.github/tests/test_changelogs.py
@@ -107,6 +107,69 @@ class TieredDiffTests(unittest.TestCase):
         self.assertIn("## All NVIDIA Images", text)
         self.assertNotIn("Additional Changes", text)
 
+    def test_hci_increment_does_not_hide_same_change_on_minimal_nvidia(self) -> None:
+        diff = {
+            "amd64": changed("hci-package", "1.0-1.fc44", "1.1-1.fc44"),
+            "arm64": changed("hci-package", "1.0-1.fc44", "1.1-1.fc44"),
+        }
+        overrides = {
+            ("ucore-hci", ""): diff,
+            ("ucore-hci", "-nvidia"): diff,
+            ("ucore-hci", "-nvidia-lts"): diff,
+            ("ucore-minimal", "-nvidia"): diff,
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertEqual(text.count("hci-package"), 2)
+        self.assertIn("## All ucore-hci Images", text)
+        self.assertIn("uCore Minimal NVIDIA — Additional Changes", text)
+
+    def test_ucore_increment_does_not_hide_same_change_on_minimal(self) -> None:
+        diff = {
+            "amd64": changed("ucore-package", "1.0-1.fc44", "1.1-1.fc44"),
+            "arm64": changed("ucore-package", "1.0-1.fc44", "1.1-1.fc44"),
+        }
+        overrides = {
+            ("ucore", ""): diff,
+            ("ucore", "-nvidia"): diff,
+            ("ucore", "-nvidia-lts"): diff,
+            ("ucore-minimal", ""): diff,
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertEqual(text.count("ucore-package"), 2)
+        self.assertIn("## All ucore Images", text)
+        self.assertIn("uCore Minimal — Additional Changes", text)
+
+    def test_open_nvidia_common_does_not_hide_same_change_on_lts(self) -> None:
+        diff = {
+            "amd64": changed("nvidia-package", "1.0-1.fc44", "1.1-1.fc44"),
+            "arm64": changed("nvidia-package", "1.0-1.fc44", "1.1-1.fc44"),
+        }
+        overrides = {
+            ("ucore-minimal", "-nvidia"): diff,
+            ("ucore", "-nvidia"): diff,
+            ("ucore-hci", "-nvidia"): diff,
+            ("ucore", "-nvidia-lts"): diff,
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertEqual(text.count("nvidia-package"), 2)
+        self.assertIn("## All NVIDIA Images", text)
+        self.assertIn("uCore NVIDIA LTS — Additional Changes", text)
+
     def test_identical_leftover_on_two_variants_is_grouped_into_one_section(self) -> None:
         # ucore-hci-nvidia inherits ucore-nvidia's layer, so an untiered change often
         # lands identically on both. It should be attributed to both, not just the first.

--- a/.github/tests/test_changelogs.py
+++ b/.github/tests/test_changelogs.py
@@ -15,6 +15,152 @@ sys.modules[SPEC.name] = CHANGELOGS
 SPEC.loader.exec_module(CHANGELOGS)
 
 
+def make_ref(image_name: str, tag_suffix: str, previous_tag: str | None) -> "CHANGELOGS.ImageRef":
+    return CHANGELOGS.ImageRef(
+        repository=f"ghcr.io/ublue-os/{image_name}",
+        tag=f"stable{tag_suffix}",
+        digest="sha256:deadbeef",
+        labels={},
+        manifests=[],
+        matched_dated_tag=f"stable{tag_suffix}-20260815",
+        previous_dated_tag=previous_tag,
+    )
+
+
+def full_refs_and_diffs(
+    overrides: dict[tuple[str, str], dict[str, "CHANGELOGS.PackageDiff"]],
+) -> tuple[dict, dict]:
+    """Build refs_by_variant/variant_diffs for all 9 VARIANTS, empty unless overridden."""
+    refs_by_variant = {}
+    variant_diffs = {}
+    for variant in CHANGELOGS.VARIANTS:
+        refs_by_variant[variant] = make_ref(variant.image_name, variant.tag_suffix, "stable-20260814")
+        variant_diffs[variant] = overrides.get((variant.image_name, variant.tag_suffix), {})
+    return refs_by_variant, variant_diffs
+
+
+def changed(name: str, previous: str, current: str) -> "CHANGELOGS.PackageDiff":
+    entry = CHANGELOGS.ChangedEntry(name=name, previous_version=previous, current_version=current)
+    return CHANGELOGS.PackageDiff(added=[], removed=[], changed=[entry])
+
+
+class TieredDiffTests(unittest.TestCase):
+    def test_change_uniform_across_a_tier_is_shown_once_not_duplicated(self) -> None:
+        diff = {"amd64": changed("systemd", "259.6-1.fc44", "259.7-1.fc44")}
+        overrides = {
+            ("ucore", ""): diff,
+            ("ucore", "-nvidia"): diff,
+            ("ucore", "-nvidia-lts"): diff,
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertIn("systemd", text)
+        self.assertIn("## All ucore Images", text)
+        self.assertNotIn("Additional Changes", text)
+
+    def test_flavor_and_arch_specific_change_is_not_silently_dropped(self) -> None:
+        # Reproduces the real xdg-dbus-proxy case: a package that only changed for one
+        # flavor (nvidia-lts) on one architecture (amd64), and nowhere else.
+        overrides = {
+            ("ucore", "-nvidia-lts"): {
+                # A comparison always covers every arch that was built; arm64 is
+                # present but empty here because it simply didn't get the bump yet.
+                "amd64": changed("xdg-dbus-proxy", "0.1.7-1.fc44", "0.1.8-1.fc44"),
+                "arm64": CHANGELOGS.PackageDiff(added=[], removed=[], changed=[]),
+            },
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertIn("xdg-dbus-proxy", text)
+        self.assertIn("uCore NVIDIA LTS — Additional Changes", text)
+        # Must be attributed to amd64 only, not printed as if it applies to both arches.
+        self.assertIn("Architecture-specific changes for `amd64`", text)
+
+    def test_change_shared_by_both_nvidia_flavors_is_shown_once_via_nvidia_section(self) -> None:
+        diff = {
+            "amd64": changed("nvidia-container-toolkit", "1.19.0-1", "1.20.0-1"),
+            "arm64": changed("nvidia-container-toolkit", "1.19.0-1", "1.20.0-1"),
+        }
+        overrides = {
+            ("ucore-minimal", "-nvidia"): diff,
+            ("ucore", "-nvidia"): diff,
+            ("ucore-hci", "-nvidia"): diff,
+            ("ucore-minimal", "-nvidia-lts"): diff,
+            ("ucore", "-nvidia-lts"): diff,
+            ("ucore-hci", "-nvidia-lts"): diff,
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertEqual(text.count("nvidia-container-toolkit"), 1)
+        self.assertIn("## All NVIDIA Images", text)
+        self.assertNotIn("Additional Changes", text)
+
+    def test_identical_leftover_on_two_variants_is_grouped_into_one_section(self) -> None:
+        # ucore-hci-nvidia inherits ucore-nvidia's layer, so an untiered change often
+        # lands identically on both. It should be attributed to both, not just the first.
+        diff = {
+            "amd64": changed("some-driver-helper", "1.0-1.fc44", "1.1-1.fc44"),
+            "arm64": CHANGELOGS.PackageDiff(added=[], removed=[], changed=[]),
+        }
+        overrides = {
+            ("ucore", "-nvidia"): diff,
+            ("ucore-hci", "-nvidia"): diff,
+        }
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertEqual(text.count("some-driver-helper"), 1)
+        self.assertIn("uCore NVIDIA / uCore HCI NVIDIA — Additional Changes", text)
+
+    def test_added_and_removed_leftover_entries_on_a_non_nvidia_variant(self) -> None:
+        diff = {
+            "amd64": CHANGELOGS.PackageDiff(
+                added=[CHANGELOGS.AddedEntry(name="new-tool", version="1.0-1.fc44")],
+                removed=[CHANGELOGS.RemovedEntry(name="old-tool", version="0.9-1.fc44")],
+                changed=[],
+            ),
+            "arm64": CHANGELOGS.PackageDiff(added=[], removed=[], changed=[]),
+        }
+        overrides = {("ucore-minimal", ""): diff}
+        refs_by_variant, variant_diffs = full_refs_and_diffs(overrides)
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertIn("uCore Minimal — Additional Changes", text)
+        self.assertIn("+ new-tool", text)
+        self.assertIn("- old-tool", text)
+
+    def test_variant_with_no_previous_dated_tag_renders_no_empty_section(self) -> None:
+        refs_by_variant, variant_diffs = full_refs_and_diffs({})
+        # Simulate a variant with nothing to compare against, per main()'s handling.
+        no_history_variant = CHANGELOGS.Variant("ucore-hci", "uCore HCI", "-nvidia-lts")
+        refs_by_variant[no_history_variant] = make_ref("ucore-hci", "-nvidia-lts", None)
+        variant_diffs[no_history_variant] = {}
+        primary_ref = refs_by_variant[CHANGELOGS.Variant("ucore", "uCore", "")]
+
+        lines = CHANGELOGS.render_tiered_diffs(primary_ref, refs_by_variant, variant_diffs)
+        text = "\n".join(lines)
+
+        self.assertNotIn("uCore HCI NVIDIA LTS — Additional Changes", text)
+
+
 class DatedTagsTests(unittest.TestCase):
     def test_uses_existing_tags_across_long_calendar_gaps(self) -> None:
         tags = [


### PR DESCRIPTION
## Summary

- The release changelog's tiered diff renderer only listed a package change if it was identical across every image/flavor variant it applied to (e.g. base + nvidia + nvidia-lts, or minimal + ucore + hci). A change limited to some of them — like an nvidia driver package bumping on x86_64 before aarch64 caught up — failed every intersection check and was silently dropped from the notes entirely, even when it was the real reason a nightly build shipped (confirmed against `release-stable-20260815`, where an `xdg-dbus-proxy` bump gated the release but never appeared anywhere in its notes).
- Add a completeness pass that renders whatever's left over after the existing sections, grouping variants that share the exact same leftover change into one section (instead of only attributing it to the first match), and padding single-arch leftovers so they're labeled as arch-specific rather than implied to apply everywhere.

## Test plan

- [x] `python3 -m unittest ../.github/tests/test_changelogs.py -v` — 9 tests, including the reproduced real-world scenario and a regression check that the arch-padding fix is actually exercised
- [x] `just check` (full repo check) from `ucore/`
- [x] Manually rendered the actual overnight `libsoup3` + `xdg-dbus-proxy` scenario through the fixed renderer and confirmed both changes now appear, with `xdg-dbus-proxy` visible as the change that gated the release