### PR TITLE
fix: restore ublue container policy after package work

### DIFF
--- a/ucore/cleanup.sh
+++ b/ucore/cleanup.sh
@@ -7,6 +7,15 @@ find /tmp/* -maxdepth 0 -type d \! -name rpms -exec rm -fr {} \; || true
 find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 find /var/cache/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
 
+# Make ublue-os-signing's policy authoritative for uCore after this stage's
+# package work; containers-common can otherwise replace it during the build.
+policy_source=/usr/share/ublue-os/signing/usr/etc/containers/policy.json
+test -f "$policy_source"
+rm -f /etc/containers/policy.json
+install -Dpm 0644 "$policy_source" /etc/containers/policy.json
+jq -e '.transports.docker["ghcr.io/ublue-os"] | any(.type == "sigstoreSigned")' \
+    /etc/containers/policy.json >/dev/null
+
 # this currently fails on /usr/etc and /var/cache
 #bootc container lint
 ostree container commit

--- a/ucore/install-ucore-minimal.sh
+++ b/ucore/install-ucore-minimal.sh
@@ -46,8 +46,8 @@ dnf -y install /tmp/rpms/akmods-zfs/ucore/ublue-os-ucore-addons*.rpm
 
 dnf -y --enable-repo='copr:copr.fedorainfracloud.org:ublue-os:packages' install ublue-os-signing
 
-# Put the policy file in the correct place and cleanup /usr/etc
-cp /usr/etc/containers/policy.json /etc/containers/policy.json
+# bootc images must not contain both /etc and /usr/etc. Remove the signing
+# package's defaults before later package installs can add persistent state.
 rm -rf /usr/etc
 
 # mitigate problem on F43 where during kernel install, dracut errors and fails

--- a/ucore/vm-test.sh
+++ b/ucore/vm-test.sh
@@ -846,6 +846,16 @@ check_swtpm_selinux() {
         "awk '\$5 == \"/usr/bin/swtpm\" { found = 1 } END { exit found }' /proc/self/mountinfo"
 }
 
+check_container_policy() {
+    local policy=/etc/containers/policy.json
+    local source=/usr/share/ublue-os/signing/usr/etc/containers/policy.json
+
+    assert_root "container policy is valid JSON" jq -e . "$policy"
+    assert_root "container policy verifies ublue images" jq -e \
+        '.transports.docker["ghcr.io/ublue-os"] | any(.type == "sigstoreSigned")' "$policy"
+    assert_root "container policy matches signing package" cmp -s "$source" "$policy"
+}
+
 validate_ucore_boot() {
     local expected_digest="$1"
     local expect_rollback="${2:-}"
@@ -874,6 +884,7 @@ validate_ucore_boot() {
 
     check_system_health
     check_swtpm_selinux
+    check_container_policy
 
     assert_root "/var marker persisted" grep -q 'source marker' /var/ucore-vm-test-marker
     assert_root "/etc marker persisted" grep -q 'ucore-vm-test persisted' /etc/ucore-vm-test.conf


### PR DESCRIPTION
Fixes #431

## Summary
- materialize the ublue-os-signing policy after each image stage's package work
- validate the deployed sigstore policy during the image build and VM boot checks
- remove the early policy copy that later package transactions can overwrite in place

## Validation
- `bash -n cleanup.sh install-ucore-minimal.sh vm-test.sh`
- `just --fmt --check`
- `python3 -m unittest discover -s ../.github/tests -v`
- `git diff --check`
- `just build`
- verified built image policy parses, contains the UBlue sigstore rule, byte-matches the signing package policy, and omits `/usr/etc`

## Known test gap
The FCOS-to-uCore and direct VM tests remain blocked by an unrelated `systemd-sysusers`/`dbus.socket` boot failure that prevents SSH from returning. The new policy assertions did not run in those tests.