### PR TITLE
docs: add ROADMAP.md for CI hardening and website launch goals

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,47 @@
+# uCore Roadmap
+
+**Now** is what we're committed to and actively prioritizing. **Later** is
+exploration — the general direction we hope to go, not yet a commitment.
+
+## Now
+
+### Goal: CI hardening
+
+Harden the build and release pipeline before it grows more publish paths
+(more on that below).
+
+- **Emergency CoreOS build override** ([#413](https://github.com/ublue-os/ucore/issues/413)) —
+  a way to pin a specific upstream Fedora CoreOS image when a new release is
+  known-bad, without disabling automatic stream discovery for everyone else.
+- **Verify checksums for CI dependencies** ([#367](https://github.com/ublue-os/ucore/issues/367)) —
+  pin and checksum-verify the build tooling and signing keys the pipeline
+  fetches at build time, the same way package manifests already are.
+- **Sandbox end-to-end publication testing** ([#414](https://github.com/ublue-os/ucore/issues/414)) —
+  a manual, isolated way to rehearse the full publish path (multi-arch
+  manifests, signing, SBOM, changelogs) without touching real release
+  streams.
+
+### Goal: projectucore.org
+
+Give the project a real home for announcements and usage docs, so GitHub can
+stay focused on code, builds, and issues.
+
+- What uCore is, which image to pick, install and rebase instructions,
+  NVIDIA/ZFS/NAS/SecureBoot guides, and release announcements move to the
+  site.
+- The project gets a visual identity — logo, colors, a real landing page —
+  instead of living entirely inside a README.
+- Generated changelogs, SBOMs, and build provenance stay right here in the
+  repo, where they're produced.
+- GitHub Issues stay focused on actionable bugs and feature work. Community
+  questions and discussion go to the [Universal Blue Discord](https://discord.gg/pPyP5hvJ2)
+  and the [Universal Blue Discourse](https://universal-blue.discourse.group/).
+
+## Later
+
+We're also exploring using [systemd-sysext](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html)
+to make NVIDIA and libvirt support optional add-ons instead of baked
+into every image variant, which would significantly shrink the number of
+image tags we publish. This is still in the design/spike stage — follow
+along via the linked issues above and future announcements once there's
+something concrete to commit to.


### PR DESCRIPTION
## Summary
- Adds `ROADMAP.md` with the two goals we're committed to right now: CI hardening (#413, #367, #414) and the projectucore.org website launch.
- Companion GitHub housekeeping done alongside this PR: retitled/relabeled #367, added a `sysext-candidate` label, closed #263 (superseded by #373), added clarifying comments to #413/#414, and created the [uCore Project Goals](https://github.com/orgs/ublue-os/projects/13) board matching the Bazzite/Aurora Project Goals convention.

## Test plan
- [x] Render `ROADMAP.md` on GitHub and confirm links (#413, #367, #414, Discord, Discourse, systemd-sysext docs) all resolve correctly