### PR TITLE
fix(pcp): install PCP SELinux policy during image build

### DIFF
--- a/ucore/install-ucore.sh
+++ b/ucore/install-ucore.sh
@@ -55,5 +55,16 @@ chmod +x "${FONT_FIX_SCRIPT}"
 rm -rf /tmp/cockpit-zfs-manager
 rm -f "${MERGERFS_RPM}" "${CZM_TGZ}" "${FONT_FIX_SCRIPT}"
 
+# pcp-selinux's %post ignores failed semodule transactions during overlay-backed
+# image builds. Install its modules explicitly in the image policy store.
+test -f /usr/share/selinux/packages/targeted/pcp.pp.bz2
+test -f /usr/share/selinux/packages/targeted/pcp-import.pp.bz2
+cp -a /etc/selinux/targeted /etc/selinux/targeted.rebuilt
+rm -rf /etc/selinux/targeted
+mv /etc/selinux/targeted.rebuilt /etc/selinux/targeted
+semodule --verbose --noreload --priority 200 --install \
+    /usr/share/selinux/packages/targeted/pcp.pp.bz2 \
+    /usr/share/selinux/packages/targeted/pcp-import.pp.bz2
+
 # tweak os-release
 sed -i '/^PRETTY_NAME/s/(uCore.*$/(uCore)"/' /usr/lib/os-release

--- a/ucore/system_files/ucore/usr/lib/tmpfiles.d/pcp-ucore.conf
+++ b/ucore/system_files/ucore/usr/lib/tmpfiles.d/pcp-ucore.conf
@@ -15,3 +15,5 @@ d /var/log/pcp/pmie 0775 pcp pcp -
 d /var/log/pcp/pmlogger 0775 pcp pcp -
 d /var/log/pcp/pmproxy 0775 pcp pcp -
 d /var/log/pcp/sa 0775 pcp pcp -
+Z /var/lib/pcp 0775 pcp pcp -
+Z /var/log/pcp 0775 pcp pcp -

--- a/ucore/vm-test.md
+++ b/ucore/vm-test.md
@@ -133,6 +133,12 @@ For images with the `swtpm` package, the test also verifies the `swtpm`,
 200, `/usr/bin/swtpm` resolves and is labeled `swtpm_exec_t`, and no bind mount
 masks that deployed file. These checks run on both target boots.
 
+For images with the `pcp` package, the test also verifies `pcp-selinux` is
+installed, the `pcp` module (and `pcp-import` when `pcp-selinux-import` is
+present) is installed at priority 200, `/usr/libexec/pcp/lib/pmcd` resolves and
+is labeled `pcp_pmcd_initrc_exec_t`, and `pmcd.service` is active. These checks
+run on both target boots.
+
 Direct mode validates the installed image digest on both boots and performs
 the same health, networking, identity, SSH-key, and persistence checks. It
 does not assert a rollback deployment because no `bootc switch` occurs.

--- a/ucore/vm-test.sh
+++ b/ucore/vm-test.sh
@@ -846,6 +846,35 @@ check_swtpm_selinux() {
         "awk '\$5 == \"/usr/bin/swtpm\" { found = 1 } END { exit found }' /proc/self/mountinfo"
 }
 
+check_pcp_selinux() {
+    if ! vm_root rpm -q pcp >/dev/null 2>&1; then
+        return
+    fi
+
+    assert_root "pcp SELinux package installed" rpm -q pcp-selinux
+    # shellcheck disable=SC2016 # The awk expression is evaluated by guest bash.
+    assert_root "pcp SELinux module installed at priority 200" bash -c '
+        semodule --list-modules=full | awk '\''
+            $1 == 200 && $2 == "pcp" { found = 1 }
+            END { exit !found }
+        '\''
+    '
+    if vm_root rpm -q pcp-selinux-import >/dev/null 2>&1; then
+        # shellcheck disable=SC2016 # The awk expression is evaluated by guest bash.
+        assert_root "pcp-import SELinux module installed at priority 200" bash -c '
+            semodule --list-modules=full | awk '\''
+                $1 == 200 && $2 == "pcp-import" { found = 1 }
+                END { exit !found }
+            '\''
+        '
+    fi
+    assert_root "pmcd initrc expected SELinux context" bash -c \
+        "matchpathcon /usr/libexec/pcp/lib/pmcd | grep -Eq 'pcp_pmcd_initrc_exec_t(:|$)'"
+    assert_root "pmcd initrc deployed SELinux context" bash -c \
+        "stat -Lc '%C' /usr/libexec/pcp/lib/pmcd | grep -Eq 'pcp_pmcd_initrc_exec_t(:|$)'"
+    assert_root "pmcd.service is active" systemctl is-active pmcd.service
+}
+
 check_container_policy() {
     local policy=/etc/containers/policy.json
     local source=/usr/share/ublue-os/signing/usr/etc/containers/policy.json
@@ -884,6 +913,7 @@ validate_ucore_boot() {
 
     check_system_health
     check_swtpm_selinux
+    check_pcp_selinux
     check_container_policy
 
     assert_root "/var marker persisted" grep -q 'source marker' /var/ucore-vm-test-marker


### PR DESCRIPTION
## Summary
- install the `pcp` and `pcp-import` SELinux modules at RPM priority 200 during `ucore` image composition, matching the nvidia/swtpm overlay workaround
- restorecon `/var/lib/pcp` and `/var/log/pcp` from tmpfiles after ostree wipes `/var`
- assert module priority, expected and deployed `pcp_pmcd_initrc_exec_t` on `/usr/libexec/pcp/lib/pmcd`, and `pmcd.service` active in VM tests

Fixes #435.

## Validation
- `just check`
- `KERNEL_VERSION=7.1.6-201.fc44.x86_64 NVIDIA_TAG=-nvidia-open TARGET_IMAGE=ucore just build`
- `just vm-test-direct localhost/ucore:stable-nvidia-open` — all PCP assertions passed on both boots; remaining failures were NVIDIA CDI in a GPU-less VM (`systemctl is-system-running` degraded)
- `bootc switch` of `git.sherman.bz/bsherman/ucore:stable-nvidia` on a `ucore:stable-nvidia` host: enforcing SELinux, wrappers labeled `pcp_*_initrc_exec_t`, `pmcd`/`pmlogger`/`pmie` active, the seven PCP units from #435 no longer failed