### PR TITLE
docs: document emergency CoreOS pin in stream-info

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,9 +10,9 @@ exploration — the general direction we hope to go, not yet a commitment.
 Harden the build and release pipeline before it grows more publish paths
 (more on that below).
 
-- **Emergency CoreOS build override** ([#413](https://github.com/ublue-os/ucore/issues/413)) —
-  a way to pin a specific upstream Fedora CoreOS image when a new release is
-  known-bad, without disabling automatic stream discovery for everyone else.
+- **Emergency CoreOS pin** ([#413](https://github.com/ublue-os/ucore/issues/413)) —
+  documented in `just stream-info`: when a Fedora CoreOS release is known-bad,
+  pin `IMAGE_VERSION` in that recipe so nightlies and PRs stay off it.
 - **Verify checksums for CI dependencies** ([#367](https://github.com/ublue-os/ucore/issues/367)) —
   pin and checksum-verify the build tooling and signing keys the pipeline
   fetches at build time, the same way package manifests already are.

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -57,7 +57,15 @@ upstream-image:
     version=$(just upstream-version "$image")
     printf '%s:%s\n' "$image" "$version"
 
-# Planned emergency CoreOS image-version override: https://github.com/ublue-os/ucore/issues/413
+# If a stream release is known-bad, pin `image` in this recipe after
+# upstream-version and before the fedora/akmods inspect. Do not edit
+# upstream-version. Example (F42 pattern from pre-#415):
+#   if [[ "${image}" == "44.YYYYMMDD.N.N" ]]; then
+#     echo "WARNING: overriding known-bad CoreOS ${image} -> 44.GOOD.N.N (#NNNN)" >&2
+#     image="44.GOOD.N.N"
+#   fi
+# The pin holds nightlies and PRs. Remove it once a good upstream exists.
+# Emergency CoreOS pin: https://github.com/ublue-os/ucore/issues/413
 stream-info output='stream-info.env':
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
## Summary

- Document the emergency CoreOS pin procedure on `just stream-info` (the F42 in-recipe pattern from pre-#415).
- Point the ROADMAP #413 bullet at that recipe instead of a dispatch-time override.

## Why

A `workflow_dispatch` pin would not hold scheduled nightlies off a known-bad Fedora CoreOS release. The former F42 hatch rewrote `IMAGE_VERSION` after discovery and before fedora/akmods resolution; that is still the right emergency move, and `stream-info` is the single path for schedule, PR, and dispatch.

Addresses #413.

## Testing

- `just --fmt --check`
- `just --list` shows: `stream-info … # Emergency CoreOS pin: https://github.com/ublue-os/ucore/issues/413`