### PR TITLE
feat(ci): pin and checksum-verify remaining CI fetches (#367)

### DIFF
--- a/.github/tests/test_github_pkg_manifests.py
+++ b/.github/tests/test_github_pkg_manifests.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+MANIFESTS = [
+    REPO / "ucore" / "github-pkgs-x86_64.json",
+    REPO / "ucore" / "github-pkgs-aarch64.json",
+    REPO / "ucore" / "github-pkgs-noarch.json",
+    REPO / "ucore" / "ci-deps.json",
+]
+
+
+class GithubPkgManifestTests(unittest.TestCase):
+    def test_manifests_exist(self) -> None:
+        for path in MANIFESTS:
+            with self.subTest(manifest=path.name):
+                self.assertTrue(path.is_file(), f"missing manifest: {path}")
+
+    def test_entries_have_required_fields(self) -> None:
+        for path in MANIFESTS:
+            with self.subTest(manifest=path.name):
+                entries = json.loads(path.read_text(encoding="utf-8"))
+                self.assertIsInstance(entries, list)
+                self.assertGreater(len(entries), 0)
+                for index, entry in enumerate(entries):
+                    name = entry.get("name", index)
+                    with self.subTest(entry=name):
+                        self.assertIsInstance(entry, dict)
+                        self.assertTrue(entry.get("name"))
+                        self.assertTrue(entry.get("url"))
+                        self.assertTrue(entry.get("repo"))
+                        self.assertRegex(entry.get("sha256", ""), SHA256_RE)
+                        self.assertTrue(entry.get("version") or entry.get("commit"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -500,8 +500,10 @@ jobs:
 
       - name: Check Secureboot
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          set -x
+          set -xeuo pipefail
           if [[ ! $(command -v sbverify) || ! $(command -v curl) || ! $(command -v openssl) ]]; then
             sudo apt update
             sudo apt install sbsigntool curl openssl
@@ -510,12 +512,9 @@ jobs:
           podman cp checksb:/usr/lib/modules/${{ env.KERNEL_VERSION }}/vmlinuz .
           podman rm -f  checksb
           sbverify --list vmlinuz
-          curl --retry 3 --retry-delay 5 -Lo kernel-sign.der https://github.com/ublue-os/kernel-cache/raw/main/certs/public_key.der
-          curl --retry 3 --retry-delay 5 -Lo akmods.der https://github.com/ublue-os/kernel-cache/raw/main/certs/public_key_2.der
-          openssl x509 -in kernel-sign.der -out kernel-sign.crt
-          openssl x509 -in akmods.der -out akmods.crt
+          kernel_sign=$(just --justfile ucore/Justfile --working-directory ucore ci-dep kernel-sign)
+          openssl x509 -in "${kernel_sign}" -out kernel-sign.crt
           sbverify --cert kernel-sign.crt vmlinuz || exit 1
-          sbverify --cert akmods.crt vmlinuz || exit 1
 
       - name: Login to GitHub Container Registry
         if: needs.workflow_info.outputs.publish == 'true'
@@ -606,6 +605,12 @@ jobs:
       - name: Mount BTRFS for podman storage
         uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6 # main
 
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
       - name: Login to GitHub Container Registry
         run: |
           printf '%s' "${{ github.token }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
@@ -644,6 +649,8 @@ jobs:
           echo "tags=${tags_space}" >> $GITHUB_OUTPUT
 
       - name: Update Buildah
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -653,11 +660,10 @@ jobs:
             *) printf "Invalid architecture" >&2; exit 1 ;;
           esac
 
-          # Buildah >=1.44.0 is incompatible with the ubuntu-24.04 Podman stack.
-          BUILDAH_VERSION=v1.43.2
-          echo "Installing Buildah $BUILDAH_VERSION for $IMAGE_ARCH"
-          curl -fsSL "https://github.com/bsherman/buildah-static/releases/download/${BUILDAH_VERSION}/buildah-${IMAGE_ARCH:?}.tar.gz" \
-            | tar -xzf - -C /usr/local/bin/
+          echo "Installing verified Buildah for $IMAGE_ARCH"
+          tgz=$(just --justfile ucore/Justfile --working-directory ucore \
+              ci-dep "buildah-${IMAGE_ARCH:?}")
+          tar -xzf "${tgz}" -C /usr/local/bin/
 
           # Workaround issues between custom buildah installation and apparmor
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^ucore/github-pkgs-(x86_64|aarch64|noarch)\\.json$/"],
+      "managerFilePatterns": [
+        "/^ucore/github-pkgs-(x86_64|aarch64|noarch)\\.json$/",
+        "/^ucore/ci-deps\\.json$/"
+      ],
       "matchStrings": [
         "\"repo\":\\s*\"(?<depName>[^\"]+)\"[^}]*?\"version\":\\s*\"(?<currentValue>[^\"]+)\""
       ],
@@ -18,16 +21,6 @@
       ],
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/{{{depName}}}"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/workflows/reusable-build\\.yml$/"],
-      "matchStrings": [
-        "BUILDAH_VERSION=(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
-      ],
-      "depNameTemplate": "bsherman/buildah-static",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [
@@ -44,7 +37,8 @@
     "fileFilters": [
       "ucore/github-pkgs-x86_64.json",
       "ucore/github-pkgs-aarch64.json",
-      "ucore/github-pkgs-noarch.json"
+      "ucore/github-pkgs-noarch.json",
+      "ucore/ci-deps.json"
     ],
     "executionMode": "update"
   }

--- a/ucore/Justfile
+++ b/ucore/Justfile
@@ -198,6 +198,10 @@ ci-prepare-build upstream_image='' arch='':
 
     just containerfile "$UPSTREAM_IMAGE"
 
+# Download and checksum-verify a pinned CI dependency. Prints the verified file path.
+ci-dep name:
+    @./github-pkgs.sh download "{{ name }}" --manifest ./ci-deps.json --release "" --arch ""
+
 # Verify one package, or all effective entries, download successfully and match the manifest checksum.
 verify-checksum package='' release='{{ FEDORA_VERSION }}' arch='':
     #!/usr/bin/env bash

--- a/ucore/ci-deps.json
+++ b/ucore/ci-deps.json
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "buildah-amd64",
+    "repo": "bsherman/buildah-static",
+    "version": "v1.43.2",
+    "url": "https://github.com/bsherman/buildah-static/releases/download/v1.43.2/buildah-amd64.tar.gz",
+    "sha256": "9f347c86602c5f56744272b5b160866eb6b46bd5f51634430ddc0b01722b2df0"
+  },
+  {
+    "name": "buildah-arm64",
+    "repo": "bsherman/buildah-static",
+    "version": "v1.43.2",
+    "url": "https://github.com/bsherman/buildah-static/releases/download/v1.43.2/buildah-arm64.tar.gz",
+    "sha256": "b08e8a006e127e3934ebb1982ee6092652ab169c469a23a7bf05c043e631fef5"
+  },
+  {
+    "name": "kernel-sign",
+    "repo": "ublue-os/akmods",
+    "branch": "main",
+    "commit": "20fce9fe76de494ff901f017a50d6f4dfc1661e0",
+    "url": "https://raw.githubusercontent.com/ublue-os/akmods/20fce9fe76de494ff901f017a50d6f4dfc1661e0/certs/public_key.der",
+    "sha256": "4e5c68474cb133fd8984d9599762cece9100c3e6cd8a9709aeaabd85dd9e70d1"
+  }
+]

--- a/ucore/ci/renovate-refresh-github-pkgs.sh
+++ b/ucore/ci/renovate-refresh-github-pkgs.sh
@@ -11,7 +11,8 @@
 # Usage:
 #   renovate-refresh-github-pkgs.sh [MANIFEST ...]
 #
-# If no manifests are given, all ucore/github-pkgs-*.json files are processed.
+# If no manifests are given, all ucore/github-pkgs-*.json files and
+# ucore/ci-deps.json are processed.
 
 set -euo pipefail
 
@@ -22,6 +23,9 @@ if [[ $# -gt 0 ]]; then
 	MANIFESTS=("$@")
 else
 	MANIFESTS=("${UCORE_DIR}"/github-pkgs-*.json)
+	if [[ -f "${UCORE_DIR}/ci-deps.json" ]]; then
+		MANIFESTS+=("${UCORE_DIR}/ci-deps.json")
+	fi
 fi
 
 fail() {
@@ -118,6 +122,19 @@ resolve_raw_commit_url() {
 	printf '%s\n' "${old_url/${old_commit}/${new_commit}}"
 }
 
+# Rewrite a non-RPM release-asset URL from repo + version + existing filename.
+# Used for ci-deps.json, where both arches live in one file and the asset name
+# is not an RPM matched by fc${release}.${arch}.
+resolve_versioned_release_url() {
+	local old_url=${1}
+	local repo=${2}
+	local version=${3}
+	local filename=${old_url##*/}
+
+	filename=${filename%%\?*}
+	printf 'https://github.com/%s/releases/download/%s/%s\n' "${repo}" "${version}" "${filename}"
+}
+
 # Dispatch to the correct resolver based on the URL shape and entry fields.
 resolve_url() {
 	local entry=${1}
@@ -146,9 +163,13 @@ resolve_url() {
 		return
 	fi
 
-	# Release asset (RPM)
+	# Release asset
 	if [[ "${url}" == */releases/download/* ]]; then
-		resolve_release_asset_url "${repo}" "${version}" "${arch}" "${release}"
+		if [[ -n "${arch}" ]]; then
+			resolve_release_asset_url "${repo}" "${version}" "${arch}" "${release}"
+		else
+			resolve_versioned_release_url "${url}" "${repo}" "${version}"
+		fi
 		return
 	fi
 
@@ -162,9 +183,14 @@ manifest_tmp=''
 trap 'rm -f "${download_file:-}" "${manifest_tmp:-}"' EXIT
 
 for manifest in "${MANIFESTS[@]}"; do
-	# Derive arch from manifest filename: github-pkgs-x86_64.json → x86_64
+	# github-pkgs-x86_64.json → x86_64. Other manifests (ci-deps.json) leave
+	# arch empty so release URLs are rewritten from version + filename.
 	arch=$(basename "${manifest}" .json)
-	arch=${arch#github-pkgs-}
+	if [[ "${arch}" == github-pkgs-* ]]; then
+		arch=${arch#github-pkgs-}
+	else
+		arch=""
+	fi
 
 	manifest_tmp=$(mktemp)
 	cp "${manifest}" "${manifest_tmp}"

--- a/ucore/github-pkgs.sh
+++ b/ucore/github-pkgs.sh
@@ -42,9 +42,17 @@ create_temp_file() {
 }
 
 get_curl_auth_args() {
-	if [[ -r /run/secrets/GITHUB_TOKEN ]]; then
-		local github_token
+	local github_token=""
+
+	if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+		github_token="${GITHUB_TOKEN}"
+	elif [[ -n "${GITHUB_COM_TOKEN:-}" ]]; then
+		github_token="${GITHUB_COM_TOKEN}"
+	elif [[ -r /run/secrets/GITHUB_TOKEN ]]; then
 		github_token=$(</run/secrets/GITHUB_TOKEN)
+	fi
+
+	if [[ -n "${github_token}" ]]; then
 		printf '%s\n%s\n' "-H" "Authorization: Bearer ${github_token}"
 	fi
 }


### PR DESCRIPTION
## Summary

- Pin and checksum-verify the remaining unverified CI fetches via a new `ucore/ci-deps.json` and `just ci-dep`, reusing `github-pkgs.sh`.
- Buildah-static is no longer `curl | tar`; the Secure Boot check downloads the current `ublue kernel` cert from `ublue-os/akmods` instead of floating `kernel-cache@main`.
- Drop the leftover `public_key_2.der` / second `sbverify`. Renovate tracks Buildah versions in the manifest; the signing-key commit stays a manual pin.

Closes #367.

## Test plan

- [x] `just check` (fmt + unit tests, including new manifest schema tests)
- [x] `just ci-dep buildah-amd64`, `buildah-arm64`, and `kernel-sign` against the live URLs
- [x] Wrong sha256 fails closed
- [x] `renovate-refresh-github-pkgs.sh ucore/ci-deps.json` is a no-op on the current pins
- [x] CI `check` workflow on this PR
- [ ] A full image build's Check Secureboot step against the single pinned cert